### PR TITLE
Allow printing custom types with their values

### DIFF
--- a/Sources/Base/SourceLocation.swift
+++ b/Sources/Base/SourceLocation.swift
@@ -38,3 +38,9 @@ struct SourceRange {
   
   static let zero = SourceRange(start: .zero, end: .zero)
 }
+
+extension SourceRange: Equatable {
+  static func ==(lhs: SourceRange, rhs: SourceRange) -> Bool {
+    return lhs.start == rhs.start && lhs.end == rhs.end
+  }
+}

--- a/Sources/Base/SourceLocation.swift
+++ b/Sources/Base/SourceLocation.swift
@@ -15,7 +15,7 @@ struct SourceLocation: CustomStringConvertible {
     self.charOffset = charOffset
   }
   var description: String {
-    return "<line: \(line), col: \(column)>"
+    return "<file: \(file ?? "<none>") line: \(line), col: \(column)>"
   }
   static let zero = SourceLocation(line: 0, column: 0)
 }

--- a/Sources/Base/Values.swift
+++ b/Sources/Base/Values.swift
@@ -225,7 +225,7 @@ class VarExpr: GenericContainingExpr, LValue {
   var decl: Decl? = nil
   init(name: Identifier, genericParams: [GenericParam] = [], sourceRange: SourceRange? = nil) {
     self.name = name
-    super.init(genericParams: genericParams, sourceRange: sourceRange)
+    super.init(genericParams: genericParams, sourceRange: sourceRange ?? name.range)
   }
   override func attributes() -> [String : Any] {
     var superAttrs = super.attributes()

--- a/Sources/IRGen/RuntimeIRGen.swift
+++ b/Sources/IRGen/RuntimeIRGen.swift
@@ -40,7 +40,6 @@ extension IRGenerator {
         return codegenCopyAny(value: value)
       }
     }
-    let irType = resolveLLVMType(type)
     let allocateAny = codegenIntrinsic(named: "trill_allocateAny")
     let meta = codegenTypeMetadata(type)
     let castMeta = builder.buildBitCast(meta,
@@ -49,8 +48,7 @@ extension IRGenerator {
     let res = builder.buildCall(allocateAny, args: [castMeta],
                                 name: "allocate-any")
     let valPtr = codegenAnyValuePtr(res, type: type)
-    let ptr = builder.buildBitCast(valPtr, type: PointerType(pointee: irType))
-    builder.buildStore(value, to: ptr)
+    builder.buildStore(value, to: valPtr)
     return res
   }
   

--- a/Sources/IRGen/StatementIRGen.swift
+++ b/Sources/IRGen/StatementIRGen.swift
@@ -35,7 +35,7 @@ extension IRGenerator {
     guard var global = binding.ref as? Global else {
       fatalError("global binding is not a Global?")
     }
-    if decl.has(attribute: .foreign) && decl.rhs != nil {
+    if decl.has(attribute: .foreign) {
       global.isExternallyInitialized = true
       return binding
     }
@@ -45,7 +45,7 @@ extension IRGenerator {
       global.isGlobalConstant = !decl.mutable
       return binding
     }
-    if context.isGlobalConstant(rhs) {
+    if context.isGlobalConstant(rhs) && !(rhs is VarExpr) {
       global.initializer = visit(rhs)!
       global.isGlobalConstant = !decl.mutable
       return binding

--- a/Sources/IRGen/TypeIRGen.swift
+++ b/Sources/IRGen/TypeIRGen.swift
@@ -110,7 +110,7 @@ extension IRGenerator {
                        .filter { !$0.isComputed }
                        .map { ($0.name.name, $0.type) }
     case .tuple(let types):
-      properties = properties.enumerated().map { (".\($0.offset)", $0.element) }
+      properties = types.enumerated().map { (".\($0.offset)", $0.element) }
     default:
       break
     }
@@ -147,7 +147,7 @@ extension IRGenerator {
     for (idx, (propName, type)) in properties.enumerated() {
       let meta = codegenTypeMetadata(type)
       
-      let name = codegenGlobalStringPtr(fieldName)
+      let name = codegenGlobalStringPtr(propName)
 
       propertyVals.append(StructType.constant(values: [
         builder.buildBitCast(name, type: PointerType.toVoid),

--- a/Sources/IRGen/TypeIRGen.swift
+++ b/Sources/IRGen/TypeIRGen.swift
@@ -114,7 +114,13 @@ extension IRGenerator {
     default:
       break
     }
-    let irType = resolveLLVMType(type)
+    var irType = resolveLLVMType(type)
+    var isIndirect = storage(for: type) == .reference
+    
+    if case .custom = type, let pointerType = irType as? PointerType {
+      isIndirect = true
+      irType = pointerType.pointee
+    }
     
     let metaName = name + ".metadata"
     let nameValue = codegenGlobalStringPtr(fullName)
@@ -160,7 +166,7 @@ extension IRGenerator {
     global.initializer = StructType.constant(values: [
       nameValue,
       builder.buildBitCast(gep, type: PointerType.toVoid),
-      IntType.int8.constant(storage(for: type) == .reference ? 1 : 0, signExtend: true),
+      IntType.int8.constant(isIndirect ? 1 : 0, signExtend: true),
       IntType.int64.constant(layout.sizeOfTypeInBits(irType), signExtend: true),
       IntType.int64.constant(properties.count, signExtend: true),
       IntType.int64.constant(pointerLevel, signExtend: true),

--- a/Sources/IRGen/ValueIRGen.swift
+++ b/Sources/IRGen/ValueIRGen.swift
@@ -286,14 +286,8 @@ extension IRGenerator {
     
     if case .as = expr.op {
       let lhs: IRValue
-      
-      // To support casting between indirect types and void pointers,
-      // don't actually load the lhs here. Just get a pointer to it.
-      if let decl = context.decl(for: expr.lhs.type!), decl.isIndirect {
-        lhs = resolvePtr(expr.lhs)
-      } else {
-        lhs = visit(expr.lhs)!
-      }
+
+      lhs = visit(expr.lhs)!
       return coerce(lhs, from: expr.lhs.type!, to: expr.type!)
     }
     

--- a/Sources/Import/ClangImporter.swift
+++ b/Sources/Import/ClangImporter.swift
@@ -411,7 +411,7 @@ class ClangImporter: Pass {
                                   modifiers: [.implicit],
                                   mutable: false,
                                   sourceRange: SourceRange(clangRange: range))
-      context.add(varDecl)
+      context.add(varDecl!)
     default:
       return
     }
@@ -429,7 +429,7 @@ class ClangImporter: Pass {
                               rhs: nil,
                               modifiers: [.foreign, .implicit],
                               mutable: false,
-                              sourceRange: identifier.range))
+                              sourceRange: identifier.range)!)
   }
   
   // FIXME: Actually use Clang's lexer instead of re-implementing parts of
@@ -612,6 +612,7 @@ class ClangImporter: Pass {
     "int32_t": .int32,
     "int16_t": .int16,
     "int8_t": .int8,
+    "TRILL_ANY": .any,
   ]
   
   func convertToTrillType(_ type: CXType) -> DataType? {

--- a/Sources/Import/ClangImporter.swift
+++ b/Sources/Import/ClangImporter.swift
@@ -103,6 +103,7 @@ class ClangImporter: Pass {
   static let headerFiles = [
     "stdlib.h",
     "stdio.h",
+    "fcntl.h",
     "stdint.h",
     "stddef.h",
     "math.h",
@@ -385,7 +386,7 @@ class ClangImporter: Pass {
     var _tokens: UnsafeMutablePointer<CXToken>?
     clang_tokenize(tu, range, &_tokens, &tokenCount)
     
-    guard let tokens = _tokens, tokenCount > 2 else { return }
+    guard let tokens = _tokens, tokenCount == 3 else { return }
     
     defer {
       clang_disposeTokens(tu, tokens, tokenCount)
@@ -395,9 +396,40 @@ class ClangImporter: Pass {
     
     let name = clang_getTokenSpelling(tu, tokens[0]).asSwift()
     guard context.global(named: Identifier(name: name)) == nil else { return }
-    guard clang_getTokenKind(tokens[1]) == CXToken_Literal else { return }
-    guard let assign = parse(tu: tu, token: tokens[1], name: name) else { return }
-    context.add(assign)
+    switch clang_getTokenKind(tokens[1]) {
+    case CXToken_Literal:
+      guard let assign = parse(tu: tu, token: tokens[1], name: name) else { return }
+      context.add(assign)
+    case CXToken_Identifier:
+      let identifierName = clang_getTokenSpelling(tu, tokens[1]).asSwift()
+      guard let _ = context.global(named: identifierName) else { return }
+      let rhs = VarExpr(name: Identifier(name: identifierName, range: SourceRange(clangRange: clang_getTokenExtent(tu, tokens[1]))))
+      let varDecl = VarAssignDecl(name: Identifier(name: name),
+                                  typeRef: nil,
+                                  kind: .global,
+                                  rhs: rhs,
+                                  modifiers: [.implicit],
+                                  mutable: false,
+                                  sourceRange: SourceRange(clangRange: range))
+      context.add(varDecl)
+    default:
+      return
+    }
+  }
+  
+  func importVariableDeclation(_ cursor: CXCursor, in tu: CXTranslationUnit, context: ASTContext) {
+    guard let type = convertToTrillType(clang_getCursorType(cursor)) else { return }
+    let name = clang_getCursorSpelling(cursor).asSwift()
+    let identifier = Identifier(name: name, range: SourceRange(clangRange: clang_getCursorExtent(cursor)))
+    if let existing = context.global(named: name), existing.sourceRange == identifier.range { return }
+    
+    context.add(VarAssignDecl(name: identifier,
+                              typeRef: type.ref(),
+                              kind: .global,
+                              rhs: nil,
+                              modifiers: [.foreign, .implicit],
+                              mutable: false,
+                              sourceRange: identifier.range))
   }
   
   // FIXME: Actually use Clang's lexer instead of re-implementing parts of
@@ -504,6 +536,8 @@ class ClangImporter: Pass {
         self.importMacro(child, in: tu, context: context)
       case CXCursor_UnionDecl:
         self.importUnion(child, context: context)
+      case CXCursor_VarDecl:
+        self.importVariableDeclation(child, in: tu, context: context)
       default:
         break
       }
@@ -577,7 +611,7 @@ class ClangImporter: Pass {
     "int64_t": .int64,
     "int32_t": .int32,
     "int16_t": .int16,
-    "int8_t": .int8
+    "int8_t": .int8,
   ]
   
   func convertToTrillType(_ type: CXType) -> DataType? {
@@ -630,11 +664,8 @@ class ClangImporter: Pass {
       guard let trillRet = convertToTrillType(ret) else { return nil }
       return .function(args: [], returnType: trillRet)
     case CXType_Typedef:
-      guard let typeName = clang_getTypeSpelling(type)
-                            .asSwift()
-                            .lastWord else {
-          return nil
-      }
+      let typeDecl = clang_getTypeDeclaration(type)
+      let typeName = clang_getCursorSpelling(typeDecl).asSwift()
       if let replacement = ClangImporter.builtinTypeReplacements[typeName] {
         return replacement
       }

--- a/Sources/Runtime/metadata.cpp
+++ b/Sources/Runtime/metadata.cpp
@@ -32,7 +32,7 @@ uint8_t trill_isReferenceType(const void *typeMeta) {
   auto real = (TypeMetadata *)typeMeta;
   return real->isReferenceType;
 }
-  
+
 uint64_t trill_getNumFields(const void *typeMeta) {
   trill_assert(typeMeta != nullptr);
   auto real = (TypeMetadata *)typeMeta;
@@ -59,30 +59,32 @@ const void *_Nullable trill_getFieldType(const void *_Nullable fieldMeta) {
   auto real = (FieldMetadata *)fieldMeta;
   return real->type;
 }
-  
+
 size_t trill_getFieldOffset(const void *_Nullable fieldMeta) {
   trill_assert(fieldMeta != nullptr);
   return ((FieldMetadata *)fieldMeta)->offset;
 }
 
-void *_Nonnull trill_allocateAny(void *typeMetadata_) {
+TRILL_ANY trill_allocateAny(void *typeMetadata_) {
   trill_assert(typeMetadata_ != nullptr);
   TypeMetadata *typeMetadata = (TypeMetadata *)typeMetadata_;
   size_t fullSize = sizeof(AnyBox) + typeMetadata->sizeInBits;
   AnyBox *ptr = (AnyBox *)trill_alloc(fullSize);
   ptr->typeMetadata = typeMetadata;
-  return ptr;
+  return {ptr};
 }
 
-void *_Nonnull trill_copyAny(void *any) {
-  trill_assert(any != nullptr);
-  AnyBox *ptr = (AnyBox *)any;
-  uint64_t size = ((TypeMetadata *)ptr->typeMetadata)->sizeInBits;
+TRILL_ANY trill_copyAny(TRILL_ANY any) {
+  AnyBox *ptr = (AnyBox *)any._any;
+  trill_assert(ptr != nullptr);
+  auto typeMetadata = reinterpret_cast<TypeMetadata*>(ptr->typeMetadata);
+  if (typeMetadata->isReferenceType) { return any; }
+  uint64_t size = typeMetadata->sizeInBits;
   AnyBox *header = (AnyBox *)trill_alloc(sizeof(AnyBox) + size);
-  memcpy(header, any, sizeof(AnyBox) + size);
-  return header;
+  memcpy(header, ptr, sizeof(AnyBox) + size);
+  return {header};
 }
-  
+
 static FieldMetadata *trill_getAnyFieldMetadata(AnyBox *any, uint64_t fieldNum) {
   auto meta = (TypeMetadata *)any->typeMetadata;
   trill_assert(meta != nullptr);
@@ -91,7 +93,7 @@ static FieldMetadata *trill_getAnyFieldMetadata(AnyBox *any, uint64_t fieldNum) 
   trill_assert(fieldMeta != nullptr);
   return fieldMeta;
 }
-  
+
 void trill_reportCastError(TypeMetadata *anyMetadata, TypeMetadata *typeMetadata) {
   std::string failureDesc = "checked cast failed: cannot convert ";
   failureDesc += trill_getTypeName(anyMetadata);
@@ -100,28 +102,35 @@ void trill_reportCastError(TypeMetadata *anyMetadata, TypeMetadata *typeMetadata
   trill_fatalError(failureDesc.c_str());
 }
 
-void *_Nonnull trill_getAnyFieldValuePtr(void *any_, uint64_t fieldNum) {
-  trill_assert(any_ != nullptr);
-  auto any = (AnyBox *)any_;
-  auto origPtr = trill_getAnyValuePtr(any);
+void *trill_getAnyFieldValuePtr(TRILL_ANY any_, uint64_t fieldNum) {
+  auto any = (AnyBox *)any_._any;
+  trill_assert(any != nullptr);
+  auto origPtr = trill_getAnyValuePtr(any_);
+  trill_assert(origPtr != nullptr);
+  auto typeMeta = reinterpret_cast<TypeMetadata*>(trill_getAnyTypeMetadata(any_));
   auto fieldMeta = trill_getAnyFieldMetadata(any, fieldNum);
+  if (typeMeta->isReferenceType) {
+    origPtr = *reinterpret_cast<void**>(origPtr);
+    trill_assert(origPtr != nullptr);
+  }
   return (void *)((intptr_t)origPtr + fieldMeta->offset);
 }
-  
-void *_Nonnull trill_extractAnyField(void *any_, uint64_t fieldNum) {
-  trill_assert(any_ != nullptr);
-  auto any = (AnyBox *)any_;
+
+TRILL_ANY trill_extractAnyField(TRILL_ANY any_, uint64_t fieldNum) {
+  auto any = (AnyBox *)any_._any;
+  trill_assert(any != nullptr);
   auto fieldMeta = trill_getAnyFieldMetadata(any, fieldNum);
   auto fieldTypeMeta = (TypeMetadata *)fieldMeta->type;
-  auto newAny = (AnyBox *)trill_allocateAny(fieldTypeMeta);
+  auto newAny = trill_allocateAny(fieldTypeMeta);
   auto fieldPtr = trill_getAnyValuePtr(newAny);
-  memcpy(fieldPtr, trill_getAnyFieldValuePtr(any, fieldNum), fieldTypeMeta->sizeInBits);
+  auto anyFieldValuePointer = trill_getAnyFieldValuePtr(any_, fieldNum);
+  memcpy(fieldPtr, anyFieldValuePointer, fieldTypeMeta->sizeInBits);
   return newAny;
 }
-  
-void trill_updateAny(void *any_, uint64_t fieldNum, void *newAny_) {
-  auto any = (AnyBox *)any_;
-  auto newAny = (AnyBox *)newAny_;
+
+void trill_updateAny(TRILL_ANY any_, uint64_t fieldNum, TRILL_ANY newAny_) {
+  auto any = (AnyBox *)any_._any;
+  auto newAny = (AnyBox *)newAny_._any;
   trill_assert(any != nullptr);
   trill_assert(newAny != nullptr);
   auto newType = (TypeMetadata *)newAny->typeMetadata;
@@ -130,20 +139,20 @@ void trill_updateAny(void *any_, uint64_t fieldNum, void *newAny_) {
   if (fieldMeta->type != newType) {
     trill_reportCastError((TypeMetadata *)fieldMeta->type, (TypeMetadata *)newAny->typeMetadata);
   }
-  auto fieldPtr = trill_getAnyFieldValuePtr(any, fieldNum);
-  auto newPtr = trill_getAnyValuePtr(newAny);
+  auto fieldPtr = trill_getAnyFieldValuePtr({any}, fieldNum);
+  auto newPtr = trill_getAnyValuePtr({newAny});
   memcpy(fieldPtr, newPtr, newType->sizeInBits);
 }
 
-void *_Nonnull trill_getAnyValuePtr(void *_Nullable anyValue) {
-  return (void *)((intptr_t)anyValue + sizeof(AnyBox));
+void *trill_getAnyValuePtr(TRILL_ANY anyValue) {
+  return (void *)((intptr_t)anyValue._any + sizeof(AnyBox));
 }
 
-void *_Nonnull trill_getAnyTypeMetadata(void *_Nonnull anyValue) {
-  trill_assert(anyValue != nullptr);
-  return ((AnyBox *)anyValue)->typeMetadata;
+void *_Nonnull trill_getAnyTypeMetadata(TRILL_ANY anyValue) {
+  trill_assert(anyValue._any != nullptr);
+  return ((AnyBox *)anyValue._any)->typeMetadata;
 }
-  
+
 void trill_debugPrintFields(const void *fields, uint64_t count, std::string indent = "") {
   for (size_t i = 0; i < count; i++) {
     FieldMetadata field = ((FieldMetadata *)fields)[i];
@@ -151,15 +160,16 @@ void trill_debugPrintFields(const void *fields, uint64_t count, std::string inde
               << trill_getTypeName(field.type) << std::endl;
   }
 }
-  
+
 void trill_debugPrintTypeMetadata(const void *ptr_, std::string indent = "") {
   if (!ptr_) {
     std::cout << "<null>" << std::endl;
     return;
   }
   TypeMetadata *ptr = (TypeMetadata *)ptr_;
+  std::string typeName = ptr->name;
   std::cout << "TypeMetadata {" << std::endl;
-  std::cout << indent << "  const char *name = \"" << ptr->name << "\"" << std::endl;
+  std::cout << indent << "  const char *name = \"" << typeName << "\"" << std::endl;
   std::cout << indent << "  const void *fields = [" << std::endl;
   trill_debugPrintFields(ptr->fields, ptr->fieldCount, indent + "  ");
   std::cout << indent << "  ]" << std::endl;
@@ -169,24 +179,26 @@ void trill_debugPrintTypeMetadata(const void *ptr_, std::string indent = "") {
   std::cout << indent << "  size_t pointerLevel = " << ptr->pointerLevel << std::endl;
   std::cout << indent << "}" << std::endl;
 }
-  
-void trill_debugPrintAny(void *ptr_) {
-  if (!ptr_) {
+
+void trill_debugPrintAny(TRILL_ANY ptr_) {
+  if (!ptr_._any) {
     std::cout << "<null>" << std::endl;
     return;
   }
-  AnyBox *ptr = (AnyBox *)ptr_;
+  AnyBox *ptr = (AnyBox *)ptr_._any;
   std::cout << "AnyBox {" << std::endl;
   std::cout << "  void *typeMetadata = ";
   trill_debugPrintTypeMetadata(ptr->typeMetadata, "  ");
   if (ptr->typeMetadata) {
-    void *valuePtr = trill_getAnyValuePtr(ptr_);
+    auto value = trill_getAnyValuePtr({ptr});
     TypeMetadata *meta = (TypeMetadata *)ptr->typeMetadata;
     std::string typeName = meta->name;
     if (typeName == "Int") {
-      std::cout << "  int64_t value = " << TYPE_PUN(valuePtr, int64_t) << std::endl;
+      std::cout << "  int64_t value = " << TYPE_PUN(value, int64_t) << std::endl;
     } else if (typeName == "Bool") {
-      std::cout << "  bool value = " << (TYPE_PUN(valuePtr, bool) ? "true" : "false") << std::endl;
+      std::cout << "  bool value = " << (TYPE_PUN(value, bool) ? "true" : "false") << std::endl;
+    } else if (strncmp(meta->name, "*", 1) == 0) {
+      std::cout << value << std::endl;
     }
   }
   std::cout << "}" << std::endl;
@@ -201,16 +213,16 @@ void trill_dumpProtocol(ProtocolMetadata *proto) {
     std::cout << "}" << std::endl;
 }
   
-uint8_t trill_checkTypes(void *anyValue_, void *typeMetadata_) {
-  AnyBox *anyValue = (AnyBox *)anyValue_;
+uint8_t trill_checkTypes(TRILL_ANY anyValue_, void *typeMetadata_) {
+  AnyBox *anyValue = (AnyBox *)anyValue_._any;
   TypeMetadata *typeMetadata = (TypeMetadata *)typeMetadata_;
   trill_assert(anyValue != nullptr);
   TypeMetadata *anyMetadata = (TypeMetadata *)anyValue->typeMetadata;
   return anyMetadata == typeMetadata;
 }
-  
-void *trill_checkedCast(void *anyValue_, void *typeMetadata_) {
-  AnyBox *anyValue = (AnyBox *)anyValue_;
+
+void *trill_checkedCast(TRILL_ANY anyValue_, void *typeMetadata_) {
+  AnyBox *anyValue = (AnyBox *)anyValue_._any;
   TypeMetadata *typeMetadata = (TypeMetadata *)typeMetadata_;
   trill_assert(anyValue != nullptr);
   TypeMetadata *anyMetadata = (TypeMetadata *)anyValue->typeMetadata;
@@ -219,5 +231,18 @@ void *trill_checkedCast(void *anyValue_, void *typeMetadata_) {
   }
   return trill_getAnyValuePtr(anyValue_);
 }
-  
+
+uint8_t trill_anyIsNil(TRILL_ANY any_) {
+  auto any = reinterpret_cast<AnyBox*>(any_._any);
+  trill_assert(any != nullptr);
+  auto metadata = reinterpret_cast<TypeMetadata*>(any->typeMetadata);
+  auto pointerLevel = metadata->pointerLevel;
+  if (pointerLevel > 0) { return 0; }
+  auto anyValuePointer = reinterpret_cast<uintptr_t*>(trill_getAnyValuePtr(any_));
+  if (*anyValuePointer == 0) {
+    return 1;
+  }
+  return 0;
+}
+
 }

--- a/Sources/Runtime/metadata.h
+++ b/Sources/Runtime/metadata.h
@@ -18,13 +18,17 @@ namespace trill {
 extern "C" {
 #endif
 
-void *_Nonnull trill_checkedCast(void *_Nullable anyValue, void *_Nonnull type);
-void *_Nonnull trill_allocateAny(void *_Nonnull type);
-void *_Nonnull trill_getAnyTypeMetadata(void *_Nonnull anyValue);
-void *_Nonnull trill_getAnyValuePtr(void *_Nullable anyValue);
-void *_Nonnull trill_copyAny(void *_Nonnull any);
-uint8_t trill_checkTypes(void *_Nullable anyValue_, void *_Nonnull typeMetadata_);
-void trill_debugPrintAny(void *_Nullable ptr);
+typedef struct TRILL_ANY {
+  void * _Nonnull _any;
+} TRILL_ANY;
+
+void *_Nonnull trill_checkedCast(TRILL_ANY anyValue, void *_Nonnull type);
+TRILL_ANY trill_allocateAny(void *_Nonnull type);
+void *_Nonnull trill_getAnyTypeMetadata(TRILL_ANY anyValue);
+void *_Nullable trill_getAnyValuePtr(TRILL_ANY anyValue);
+TRILL_ANY trill_copyAny(TRILL_ANY any);
+uint8_t trill_checkTypes(TRILL_ANY anyValue_, void *_Nonnull typeMetadata_);
+void trill_debugPrintAny(TRILL_ANY ptr);
 const char *_Nonnull trill_getTypeName(const void *_Nullable typeMeta);
 uint64_t trill_getTypeSizeInBits(const void *_Nullable typeMeta);
 const void *_Nullable trill_getFieldMetadata(const void *_Nullable typeMeta, uint64_t field);
@@ -33,8 +37,9 @@ const char *_Nullable trill_getFieldName(const void *_Nullable fieldMeta);
 const void *_Nullable trill_getFieldType(const void *_Nullable fieldMeta);
 size_t trill_getFieldOffset(const void *_Nullable fieldMeta);
 uint8_t trill_isReferenceType(const void *_Nullable typeMeta);
-void *_Nonnull trill_extractAnyField(void *_Nonnull any_, uint64_t fieldNum);
-void trill_updateAny(void *_Nonnull any_, uint64_t fieldNum, void *_Nonnull newAny_);
+TRILL_ANY trill_extractAnyField(TRILL_ANY any_, uint64_t fieldNum);
+void trill_updateAny(TRILL_ANY any_, uint64_t fieldNum, TRILL_ANY newAny_);
+uint8_t trill_anyIsNil(TRILL_ANY any_);
 
 #ifdef __cplusplus
 }

--- a/Sources/Runtime/runtime.cpp
+++ b/Sources/Runtime/runtime.cpp
@@ -73,10 +73,11 @@ void trill_fatalError(const char *_Nonnull message) {
 }
 
 void *trill_alloc(size_t size) {
-    void *ptr = malloc(size); //GC_MALLOC(size);
+  void *ptr = malloc(size); //GC_MALLOC(size);
   if (!ptr) {
     trill_fatalError((char *)"malloc failed");
   }
+  memset(ptr, 0, size);
   return ptr;
 }
 

--- a/Sources/Semantic Analysis/Sema.swift
+++ b/Sources/Semantic Analysis/Sema.swift
@@ -284,7 +284,7 @@ class Sema: ASTTransformer, Pass {
       return .property
     }
     if let type = expr.lhs.type, case .pointer(_) = context.canonicalType(type) {
-      error(SemaError.pointerFieldAccess(lhs: type, field: expr.name),
+      error(SemaError.pointerPropertyAccess(lhs: type, property: expr.name),
             loc: expr.dotLoc,
             highlights: [
               expr.name.range
@@ -293,9 +293,17 @@ class Sema: ASTTransformer, Pass {
     }
     if case .function = type {
       error(SemaError.fieldOfFunctionType(type: type),
-            loc: expr.startLoc,
+            loc: expr.dotLoc,
             highlights: [
               expr.sourceRange
+        ])
+      return .property
+    }
+    if case .tuple = type {
+      error(SemaError.tuplePropertyAccess(lhs: type, property: expr.name),
+            loc: expr.dotLoc,
+            highlights: [
+              expr.name.range
         ])
       return .property
     }

--- a/Sources/Semantic Analysis/SemaError.swift
+++ b/Sources/Semantic Analysis/SemaError.swift
@@ -50,7 +50,8 @@ enum SemaError: Error, CustomStringConvertible {
   case cannotOverloadOperator(op: BuiltinOperator, type: String)
   case typeDoesNotConform(DataType, protocol: DataType)
   case missingImplementation(FuncDecl)
-  case pointerFieldAccess(lhs: DataType, field: Identifier)
+  case pointerPropertyAccess(lhs: DataType, property: Identifier)
+  case tuplePropertyAccess(lhs: DataType, property: Identifier)
 
   var description: String {
     switch self {
@@ -158,8 +159,10 @@ enum SemaError: Error, CustomStringConvertible {
       return "'\(typeName)' does not conform to protocol '\(`protocol`)'"
     case .missingImplementation(let decl):
       return "missing implementation for '\(decl.formattedName)'"
-    case .pointerFieldAccess(let lhs, let field):
-      return "cannot access field \(field) of pointer type \(lhs)"
+    case .pointerPropertyAccess(let lhs, let property):
+      return "cannot access property \(property) of pointer type \(lhs)"
+    case .tuplePropertyAccess(let lhs, let property):
+      return "cannot access property \(property) on tuple type \(lhs)"
     }
   }
 }

--- a/Trill.xcodeproj/xcshareddata/xcschemes/Trill.xcscheme
+++ b/Trill.xcodeproj/xcshareddata/xcschemes/Trill.xcscheme
@@ -61,6 +61,32 @@
             ReferencedContainer = "container:Trill.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "${PROJECT_DIR}/examples/fact.tr"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "$(PROJECT_DIR)/stdlib/Int.tr"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "$(PROJECT_DIR)/stdlib/Mirror.tr"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "$(PROJECT_DIR)/stdlib/String.tr"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "$(PROJECT_DIR)/stdlib/bytearray.tr"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "$(PROJECT_DIR)/stdlib/print.tr"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/stdlib/Mirror.tr
+++ b/stdlib/Mirror.tr
@@ -27,11 +27,11 @@ type Mirror {
   }
 
   func child(_ index: Int) -> Any {
-    return trill_extractAnyField(*((&self.value) as **Void), index as UInt)
+    return trill_extractAnyField(self.value, index as UInt)
   }
 
   func set(value: Any, forChild index: Int) {
-    trill_updateAny(*((&self.value) as **Void), index as UInt, *((&value) as **Void))
+    trill_updateAny(self.value, index as UInt, value)
   }
 
   func set(value: Any, forKey name: *Int8) {

--- a/stdlib/Mirror.tr
+++ b/stdlib/Mirror.tr
@@ -64,6 +64,27 @@ type Mirror {
     }
   }
 
+  func print(to file: *FILE) {
+    if trill_anyIsNil(self.value) != 0 {
+      fprintf(file, "nil")
+      return
+    }
+    fprintf(file, "%s(", self.name())
+    for var i = 0; i < self.numberOfFields(); i += 1 {
+      let field = self.field(at: i)
+      if i != 0 { fprintf(file, ", ") }
+      let name = field.name()
+      if name == nil { // tuple
+        fprintf(file, ".%d: ", i)
+      }
+      else {
+        fprintf(file, "%s: ", name)
+      }
+      print(self.child(i))
+    }
+    fprintf(file, ")", self.value)
+  }
+
   func field(at index: Int) -> FieldMirror {
     return FieldMirror(reflecting: trill_getFieldMetadata(self._metadata, index as UInt))
   }

--- a/stdlib/print.tr
+++ b/stdlib/print.tr
@@ -5,8 +5,12 @@ func print(_ value: Any) {
     print(value as Int)
   } else if value is Bool {
     print(value as Bool)
+  } else if value is *Void {
+    printf("%p", value as *Void)
+  } else if value is String {
+    print(value as String)
   } else {
-    printf("<%s 0x%p>", Mirror(reflecting: value).name(), value)
+    Mirror(reflecting: value).print(to: stdout)
   }
 }
 


### PR DESCRIPTION
this now works

```swift
indirect type Foo {
  let x: Int
  var y: Foo
  let z: String
}

type Bar {
  let x: Int
  let z: String
}

func fhdjsfhjskdhfjkds() {
  let x = 5 as Any
  println(x as Int)
}

func nooooo() {
  let x = Bar(x: 5, z: String(cString: "fdshfjkdshfksd")) as Any
  println(x)
}

func main() {
  nooooo()
  fhdjsfhjskdhfjkds()
  let x = ("a", 4) //as Any

  println(x)
  let anyX = x as Any

  let foo = Foo(x: 0, y:
      Foo(x: 6540, y: nil, z: String(cString: "fdshfjkdshfksd")),
    z: String(cString: "fdsfs"))

  println(((foo.y as Any) as Foo).x)
  println(foo)
}
```