### PR TITLE
Cleaned up metadata code

### DIFF
--- a/Sources/Runtime/generics.cpp
+++ b/Sources/Runtime/generics.cpp
@@ -7,9 +7,9 @@ using namespace trill;
 void *trill_createGenericBox(const void *typeMetadata, const void **witnessTable) {
     trill_assert(typeMetadata != nullptr);
     trill_assert(witnessTable != nullptr);
-    auto metadata = (TypeMetadata *)typeMetadata;
+    auto metadata = reinterpret_cast<const TypeMetadata *>(typeMetadata);
     auto fullSize = sizeof(GenericBox) + metadata->sizeInBits;
-    auto box = (GenericBox *)trill_alloc(fullSize);
+    auto box = reinterpret_cast<GenericBox *>(trill_alloc(fullSize));
     trill_assert(box != nullptr);
     box->typeMetadata = metadata;
     box->witnessTable = witnessTable;
@@ -18,5 +18,5 @@ void *trill_createGenericBox(const void *typeMetadata, const void **witnessTable
 
 void *trill_genericBoxValuePtr(void *box) {
     trill_assert(box != nullptr);
-    return ((intptr_t *)box) + sizeof(GenericBox);
+    return reinterpret_cast<intptr_t *>(box) + sizeof(GenericBox);
 }

--- a/Sources/Runtime/generics.cpp
+++ b/Sources/Runtime/generics.cpp
@@ -4,7 +4,7 @@
 
 using namespace trill;
 
-void *trill_createGenericBox(void *typeMetadata, void *witnessTable) {
+void *trill_createGenericBox(const void *typeMetadata, const void **witnessTable) {
     trill_assert(typeMetadata != nullptr);
     trill_assert(witnessTable != nullptr);
     auto metadata = (TypeMetadata *)typeMetadata;

--- a/Sources/Runtime/metadata.cpp
+++ b/Sources/Runtime/metadata.cpp
@@ -17,84 +17,80 @@ namespace trill {
 
 const char *trill_getTypeName(const void *typeMeta) {
   trill_assert(typeMeta != nullptr);
-  auto real = (TypeMetadata *)typeMeta;
-  return real->name;
+  return reinterpret_cast<const TypeMetadata *>(typeMeta)->name;
 }
 
 uint64_t trill_getTypeSizeInBits(const void *typeMeta) {
   trill_assert(typeMeta != nullptr);
-  auto real = (TypeMetadata *)typeMeta;
-  return real->sizeInBits;
+  return reinterpret_cast<const TypeMetadata *>(typeMeta)->sizeInBits;
 }
 
 uint8_t trill_isReferenceType(const void *typeMeta) {
   trill_assert(typeMeta != nullptr);
-  auto real = (TypeMetadata *)typeMeta;
-  return real->isReferenceType;
+  return reinterpret_cast<const TypeMetadata *>(typeMeta)->isReferenceType;
 }
 
 uint64_t trill_getNumFields(const void *typeMeta) {
   trill_assert(typeMeta != nullptr);
-  auto real = (TypeMetadata *)typeMeta;
-  return real->fieldCount;
+  return reinterpret_cast<const TypeMetadata *>(typeMeta)->fieldCount;
 }
 
 const void *_Nullable trill_getFieldMetadata(const void *typeMeta, uint64_t field) {
   trill_assert(typeMeta != nullptr);
-  auto real = (TypeMetadata *)typeMeta;
+  auto real = reinterpret_cast<const TypeMetadata *>(typeMeta);
   if (real->fieldCount <= field) {
     trill_fatalError("field index out of bounds");
   }
-  return &((FieldMetadata *)real->fields)[field];
+  return &(real->fields[field]);
 }
 
-const char *_Nullable trill_getFieldName(const void *_Nullable fieldMeta) {
+const char *_Nonnull trill_getFieldName(const void *_Nonnull fieldMeta) {
   trill_assert(fieldMeta != nullptr);
-  auto real = (FieldMetadata *)fieldMeta;
-  return real->name;
+  return reinterpret_cast<const FieldMetadata *>(fieldMeta)->name;
 }
 
-const void *_Nullable trill_getFieldType(const void *_Nullable fieldMeta) {
+const void *_Nonnull trill_getFieldType(const void *_Nonnull fieldMeta) {
   trill_assert(fieldMeta != nullptr);
-  auto real = (FieldMetadata *)fieldMeta;
-  return real->type;
+  return reinterpret_cast<const FieldMetadata *>(fieldMeta)->typeMetadata;
 }
 
 size_t trill_getFieldOffset(const void *_Nullable fieldMeta) {
   trill_assert(fieldMeta != nullptr);
-  return ((FieldMetadata *)fieldMeta)->offset;
+  return reinterpret_cast<const FieldMetadata *>(fieldMeta)->offset;
 }
 
-TRILL_ANY trill_allocateAny(void *typeMetadata_) {
-  trill_assert(typeMetadata_ != nullptr);
-  TypeMetadata *typeMetadata = (TypeMetadata *)typeMetadata_;
-  size_t fullSize = sizeof(AnyBox) + typeMetadata->sizeInBits;
-  AnyBox *ptr = (AnyBox *)trill_alloc(fullSize);
+TRILL_ANY trill_allocateAny(const void *typeMeta) {
+  trill_assert(typeMeta != nullptr);
+  auto typeMetadata = reinterpret_cast<const TypeMetadata *>(typeMeta);
+  auto fullSize = sizeof(AnyBox) + typeMetadata->sizeInBits;
+  auto ptr = reinterpret_cast<AnyBox *>(trill_alloc(fullSize));
   ptr->typeMetadata = typeMetadata;
   return {ptr};
 }
 
 TRILL_ANY trill_copyAny(TRILL_ANY any) {
-  AnyBox *ptr = (AnyBox *)any._any;
+  auto ptr = any.any();
   trill_assert(ptr != nullptr);
-  auto typeMetadata = reinterpret_cast<TypeMetadata*>(ptr->typeMetadata);
+  auto typeMetadata = ptr->typeMetadata;
   if (typeMetadata->isReferenceType) { return any; }
-  uint64_t size = typeMetadata->sizeInBits;
-  AnyBox *header = (AnyBox *)trill_alloc(sizeof(AnyBox) + size);
-  memcpy(header, ptr, sizeof(AnyBox) + size);
-  return {header};
+  auto newAny = trill_allocateAny(typeMetadata);
+  auto valuePtr = trill_getAnyValuePtr(any);
+  auto newValuePtr = trill_getAnyValuePtr(newAny);
+  memcpy(newValuePtr, valuePtr, typeMetadata->sizeInBits);
+  return newAny;
 }
 
-static FieldMetadata *trill_getAnyFieldMetadata(AnyBox *any, uint64_t fieldNum) {
-  auto meta = (TypeMetadata *)any->typeMetadata;
+static const FieldMetadata *trill_getAnyFieldMetadata(AnyBox *any,
+                                                      uint64_t fieldNum) {
+  auto meta = any->typeMetadata;
   trill_assert(meta != nullptr);
   trill_assert(fieldNum < meta->fieldCount);
-  auto fieldMeta = (FieldMetadata *)trill_getFieldMetadata(meta, fieldNum);
+  auto fieldMeta = trill_getFieldMetadata(meta, fieldNum);
   trill_assert(fieldMeta != nullptr);
-  return fieldMeta;
+  return reinterpret_cast<const FieldMetadata *>(fieldMeta);
 }
 
-void trill_reportCastError(TypeMetadata *anyMetadata, TypeMetadata *typeMetadata) {
+void trill_reportCastError(const TypeMetadata *anyMetadata, const TypeMetadata *typeMetadata) {
   std::string failureDesc = "checked cast failed: cannot convert ";
   failureDesc += trill_getTypeName(anyMetadata);
   failureDesc += " to ";
@@ -103,24 +99,24 @@ void trill_reportCastError(TypeMetadata *anyMetadata, TypeMetadata *typeMetadata
 }
 
 void *trill_getAnyFieldValuePtr(TRILL_ANY any_, uint64_t fieldNum) {
-  auto any = (AnyBox *)any_._any;
+  auto any = any_.any();
   trill_assert(any != nullptr);
   auto origPtr = trill_getAnyValuePtr(any_);
   trill_assert(origPtr != nullptr);
-  auto typeMeta = reinterpret_cast<TypeMetadata*>(trill_getAnyTypeMetadata(any_));
+  auto typeMeta = any->typeMetadata;
   auto fieldMeta = trill_getAnyFieldMetadata(any, fieldNum);
   if (typeMeta->isReferenceType) {
-    origPtr = *reinterpret_cast<void**>(origPtr);
+    origPtr = *reinterpret_cast<void **>(origPtr);
     trill_assert(origPtr != nullptr);
   }
   return (void *)((intptr_t)origPtr + fieldMeta->offset);
 }
 
 TRILL_ANY trill_extractAnyField(TRILL_ANY any_, uint64_t fieldNum) {
-  auto any = (AnyBox *)any_._any;
+  auto any = any_.any();
   trill_assert(any != nullptr);
   auto fieldMeta = trill_getAnyFieldMetadata(any, fieldNum);
-  auto fieldTypeMeta = (TypeMetadata *)fieldMeta->type;
+  auto fieldTypeMeta = fieldMeta->typeMetadata;
   auto newAny = trill_allocateAny(fieldTypeMeta);
   auto fieldPtr = trill_getAnyValuePtr(newAny);
   auto anyFieldValuePointer = trill_getAnyFieldValuePtr(any_, fieldNum);
@@ -129,35 +125,39 @@ TRILL_ANY trill_extractAnyField(TRILL_ANY any_, uint64_t fieldNum) {
 }
 
 void trill_updateAny(TRILL_ANY any_, uint64_t fieldNum, TRILL_ANY newAny_) {
-  auto any = (AnyBox *)any_._any;
-  auto newAny = (AnyBox *)newAny_._any;
+  auto any = any_.any();
+  auto newAny = newAny_.any();
   trill_assert(any != nullptr);
   trill_assert(newAny != nullptr);
-  auto newType = (TypeMetadata *)newAny->typeMetadata;
+  auto newType = newAny->typeMetadata;
   trill_assert(newType);
   auto fieldMeta = trill_getAnyFieldMetadata(any, fieldNum);
-  if (fieldMeta->type != newType) {
-    trill_reportCastError((TypeMetadata *)fieldMeta->type, (TypeMetadata *)newAny->typeMetadata);
+  if (fieldMeta->typeMetadata != newType) {
+    trill_reportCastError(fieldMeta->typeMetadata, newAny->typeMetadata);
   }
   auto fieldPtr = trill_getAnyFieldValuePtr({any}, fieldNum);
   auto newPtr = trill_getAnyValuePtr({newAny});
   memcpy(fieldPtr, newPtr, newType->sizeInBits);
 }
 
-void *trill_getAnyValuePtr(TRILL_ANY anyValue) {
-  return (void *)((intptr_t)anyValue._any + sizeof(AnyBox));
+void *_Nonnull trill_getAnyValuePtr(TRILL_ANY anyValue) {
+  return reinterpret_cast<void *>((intptr_t)anyValue._any + sizeof(AnyBox));
 }
 
-void *_Nonnull trill_getAnyTypeMetadata(TRILL_ANY anyValue) {
+const void *_Nonnull trill_getAnyTypeMetadata(TRILL_ANY anyValue) {
   trill_assert(anyValue._any != nullptr);
-  return ((AnyBox *)anyValue._any)->typeMetadata;
+  return anyValue.any()->typeMetadata;
 }
 
-void trill_debugPrintFields(const void *fields, uint64_t count, std::string indent = "") {
+void trill_debugPrintFields(const FieldMetadata *fields,
+                            uint64_t count,
+                            std::string indent = "") {
   for (size_t i = 0; i < count; i++) {
-    FieldMetadata field = ((FieldMetadata *)fields)[i];
-    std::cout << indent << "  " << field.name << ": "
-              << trill_getTypeName(field.type) << std::endl;
+    auto field = fields[i];
+    std::string typeName = field.typeMetadata->name;
+    std::string fieldName = field.name;
+    std::cout << indent << "  " << fieldName << ": "
+              << typeName << std::endl;
   }
 }
 
@@ -166,7 +166,7 @@ void trill_debugPrintTypeMetadata(const void *ptr_, std::string indent = "") {
     std::cout << "<null>" << std::endl;
     return;
   }
-  TypeMetadata *ptr = (TypeMetadata *)ptr_;
+  auto ptr = reinterpret_cast<const TypeMetadata *>(ptr_);
   std::string typeName = ptr->name;
   std::cout << "TypeMetadata {" << std::endl;
   std::cout << indent << "  const char *name = \"" << typeName << "\"" << std::endl;
@@ -191,7 +191,7 @@ void trill_debugPrintAny(TRILL_ANY ptr_) {
   trill_debugPrintTypeMetadata(ptr->typeMetadata, "  ");
   if (ptr->typeMetadata) {
     auto value = trill_getAnyValuePtr({ptr});
-    TypeMetadata *meta = (TypeMetadata *)ptr->typeMetadata;
+    auto meta = ptr->typeMetadata;
     std::string typeName = meta->name;
     if (typeName == "Int") {
       std::cout << "  int64_t value = " << TYPE_PUN(value, int64_t) << std::endl;
@@ -213,19 +213,19 @@ void trill_dumpProtocol(ProtocolMetadata *proto) {
     std::cout << "}" << std::endl;
 }
   
-uint8_t trill_checkTypes(TRILL_ANY anyValue_, void *typeMetadata_) {
-  AnyBox *anyValue = (AnyBox *)anyValue_._any;
-  TypeMetadata *typeMetadata = (TypeMetadata *)typeMetadata_;
-  trill_assert(anyValue != nullptr);
-  TypeMetadata *anyMetadata = (TypeMetadata *)anyValue->typeMetadata;
+uint8_t trill_checkTypes(TRILL_ANY anyValue_, const void *typeMetadata_) {
+  auto any = anyValue_.any();
+  auto typeMetadata = reinterpret_cast<const TypeMetadata *>(typeMetadata_);
+  trill_assert(any != nullptr);
+  auto anyMetadata = any->typeMetadata;
   return anyMetadata == typeMetadata;
 }
 
-void *trill_checkedCast(TRILL_ANY anyValue_, void *typeMetadata_) {
-  AnyBox *anyValue = (AnyBox *)anyValue_._any;
-  TypeMetadata *typeMetadata = (TypeMetadata *)typeMetadata_;
-  trill_assert(anyValue != nullptr);
-  TypeMetadata *anyMetadata = (TypeMetadata *)anyValue->typeMetadata;
+const void *trill_checkedCast(TRILL_ANY anyValue_, const void *typeMetadata_) {
+  auto any = anyValue_.any();
+  auto typeMetadata = reinterpret_cast<const TypeMetadata *>(typeMetadata_);
+  trill_assert(any != nullptr);
+  auto anyMetadata = any->typeMetadata;
   if (anyMetadata != typeMetadata) {
     trill_reportCastError(anyMetadata, typeMetadata);
   }
@@ -233,12 +233,12 @@ void *trill_checkedCast(TRILL_ANY anyValue_, void *typeMetadata_) {
 }
 
 uint8_t trill_anyIsNil(TRILL_ANY any_) {
-  auto any = reinterpret_cast<AnyBox*>(any_._any);
+  auto any = any_.any();
   trill_assert(any != nullptr);
-  auto metadata = reinterpret_cast<TypeMetadata*>(any->typeMetadata);
+  auto metadata = any->typeMetadata;
   auto pointerLevel = metadata->pointerLevel;
   if (pointerLevel > 0) { return 0; }
-  auto anyValuePointer = reinterpret_cast<uintptr_t*>(trill_getAnyValuePtr(any_));
+  auto anyValuePointer = reinterpret_cast<uintptr_t *>(trill_getAnyValuePtr(any_));
   if (*anyValuePointer == 0) {
     return 1;
   }

--- a/Sources/Runtime/metadata.h
+++ b/Sources/Runtime/metadata.h
@@ -14,32 +14,243 @@
 #include <stdio.h>
 
 #ifdef __cplusplus
+struct AnyBox;
+
 namespace trill {
 extern "C" {
 #endif
 
+
+/**
+ `TRILL_ANY` is a special type understood by the Trill compiler as the
+ representation of an `Any` value.
+ */
 typedef struct TRILL_ANY {
   void * _Nonnull _any;
+#ifdef __cplusplus
+  AnyBox *_Nonnull any() {
+    return reinterpret_cast<AnyBox *>(_any);
+  }
+#endif
 } TRILL_ANY;
 
-void *_Nonnull trill_checkedCast(TRILL_ANY anyValue, void *_Nonnull type);
-TRILL_ANY trill_allocateAny(void *_Nonnull type);
-void *_Nonnull trill_getAnyTypeMetadata(TRILL_ANY anyValue);
-void *_Nullable trill_getAnyValuePtr(TRILL_ANY anyValue);
-TRILL_ANY trill_copyAny(TRILL_ANY any);
-uint8_t trill_checkTypes(TRILL_ANY anyValue_, void *_Nonnull typeMetadata_);
-void trill_debugPrintAny(TRILL_ANY ptr);
-const char *_Nonnull trill_getTypeName(const void *_Nullable typeMeta);
-uint64_t trill_getTypeSizeInBits(const void *_Nullable typeMeta);
-const void *_Nullable trill_getFieldMetadata(const void *_Nullable typeMeta, uint64_t field);
-uint64_t trill_getNumFields(const void *_Nullable typeMeta);
-const char *_Nullable trill_getFieldName(const void *_Nullable fieldMeta);
-const void *_Nullable trill_getFieldType(const void *_Nullable fieldMeta);
+/**
+ Gets the formatted name of a given Trill type metadata object.
+
+ @param typeMeta The type metadata.
+ @return The name inside the type metadata. This is the same name
+         that would appear in source code.
+ */
+const char *_Nonnull trill_getTypeName(const void *_Nonnull typeMeta);
+
+
+/**
+ Gets the size of type metadata in bits. This takes into account the specific
+ LLVM sizing properties of the underlying type.
+
+ @param typeMeta The type metadata.
+ @return The size of the type, in bits, suitable for pointer arithmetic.
+ */
+uint64_t trill_getTypeSizeInBits(const void *_Nonnull typeMeta);
+
+
+/**
+ Determines whether or not this metadata represents a reference type, i.e.
+ a type spelled `indirect type` in Trill.
+
+ @param typeMeta The type metadata.
+ @return A non-zero value if the metadata is a reference type, and 0
+         otherwise.
+ */
+uint8_t trill_isReferenceType(const void *_Nonnull typeMeta);
+
+
+/**
+ Gets the number of fields from type metadata. Primitive types will have no
+ fields, while record types (structs and tuples) will have fields.
+
+ @param typeMeta The type metadata.
+ @return The number of fields in this type.
+ */
+uint64_t trill_getNumFields(const void *_Nonnull typeMeta);
+
+
+/**
+ Gets the `FieldMetadata` associated with the provided field index into the
+ provided `TypeMetadata`.
+ 
+ @note This function will abort if the field index is out of bounds. Ensure
+       the field you pass in is in-bounds by calling `trill_getNumFields` and
+       comparing the result.
+
+ @param typeMeta The type metadata.
+ @param field The index of the field you wish to inspect.
+ */
+const void *_Nonnull trill_getFieldMetadata(const void *_Nonnull typeMeta,
+                                             uint64_t field);
+
+
+/**
+ Gets the name of the provided `FieldMetadata`.
+
+ @param fieldMeta The field metadata.
+ @return A constant C string with the field's name as declared in the source.
+ */
+const char *_Nonnull trill_getFieldName(const void *_Nonnull fieldMeta);
+
+
+/**
+ Gets the `TypeMetadata` of the provided `FieldMetadata`.
+
+ @param fieldMeta The field metadata.
+ @return The metadata of the field's type.
+ */
+const void *_Nonnull trill_getFieldType(const void *_Nonnull fieldMeta);
+
+
+/**
+ Gets the offset of a field (in bytes) from the start of a type.
+
+ @param fieldMeta The field metadata.
+ @return The offset in bytes of a field in a composite type.
+ */
 size_t trill_getFieldOffset(const void *_Nullable fieldMeta);
-uint8_t trill_isReferenceType(const void *_Nullable typeMeta);
+
+
+/**
+ Creates an `Any` representation with the provided type metadata.
+ An `Any` in Trill is a variable-sized, heap-allocated box that holds:
+
+ - Type metadata for the underlying object, and
+ - A payload that is the size specified in the metadata.
+ 
+ @note This value is uninitialized, and the payload will be empty. You
+       must initialize the payload with a value by casting and storing
+       the value into the pointer returned by `trill_getAnyValuePtr`.
+
+ @param typeMeta The type metadata for the underlying value.
+ @return A new `Any` box that is uninitialized.
+ */
+TRILL_ANY trill_allocateAny(const void *_Nonnull typeMeta);
+
+
+/**
+ Copies an `Any` if the underlying value's semantics mean it should be copied.
+ If the underlying value is a reference type, then the provided `Any` is just
+ returned unmodified.
+
+ @param any The `Any` you wish to copy.
+ @return A new `Any` containing the contents of the old `Any`, if the
+         underlying value is has value semantics. Otherwise, the provided
+         `Any`.
+ */
+TRILL_ANY trill_copyAny(TRILL_ANY any);
+
+/**
+ Gets a pointer to a field inside the `Any` structure. Specifically, this
+ is a pointer inside the payload that will, when stored, update the value
+ inside the payload.
+
+ @note This function will abort if the field index is out of bounds. Ensure
+       the field you pass in is in-bounds by calling `trill_getNumFields` and
+       comparing the result.
+
+ @param any_ The `Any` you're inspecting.
+ @param fieldNum The field index you're accessing.
+ @return A pointer into the payload that points to the value of the
+         provided field.
+ */
+void *_Nonnull trill_getAnyFieldValuePtr(TRILL_ANY any_, uint64_t fieldNum);
+
+
+/**
+ Extracts a field from this payload and wraps it in its own `Any` container.
+ 
+
+ @note This function will abort if the field index is out of bounds. Ensure
+       the field you pass in is in-bounds by calling `trill_getNumFields` and
+       comparing the result.
+
+ @param any_ The composite type from which you're extracting a field.
+ @param fieldNum The field index.
+ @return A new `Any` with a payload that comes from the field's contents.
+ */
 TRILL_ANY trill_extractAnyField(TRILL_ANY any_, uint64_t fieldNum);
+
+
+/**
+ Updates a field with the value inside the provided `Any`.
+
+ @param any_ The `Any` for the composite type whose field you are replacing.
+ @param fieldNum The index of the field to be replaced.
+ @param newAny_ The `Any` for the underlying field.
+ */
 void trill_updateAny(TRILL_ANY any_, uint64_t fieldNum, TRILL_ANY newAny_);
+
+
+/**
+ Gets a pointer to the payload that can be cast and stored.
+ 
+ @note This will perform no casting or type checking for you, and should only
+       be used opaquely or if you are absolutely sure of the underlying type.
+
+ @param anyValue The `Any` whose payload you want to use.
+ @return A pointer to the payload that can be cast and then loaded from.
+ */
+void *_Nonnull trill_getAnyValuePtr(TRILL_ANY anyValue);
+
+
+/**
+ Gets the `TypeMetadata` underlying an `Any` box.
+
+ @param anyValue The `Any` box.
+ @return The underlying type metadata.
+ */
+const void *_Nonnull trill_getAnyTypeMetadata(TRILL_ANY anyValue);
+
+
+/**
+ Checks if the underlying metadata of an `Any` matches the metadata provided.
+
+ @param anyValue_ The `Any` whose type you're checking.
+ @param typeMetadata_ The `TypeMetadata` you're checking.
+ @return A non-zero value if the type metadata underlying the `Any` box
+         is pointer-equal to the provided `TypeMetadata`. Otherwise, 0.
+ */
+uint8_t trill_checkTypes(TRILL_ANY anyValue_,
+                         const void *_Nonnull typeMetadata_);
+
+
+/**
+ Checks if the underlying metadata of an `Any` box matches the provided
+ metadata, and returns a pointer to the underlying payload if they do.
+ 
+ @note If the `Any` value does not match the provided metadata, then this
+       function causes a fatal error with a descriptive message and then
+       aborts with a stack trace.
+
+ @param anyValue_ The `Any` you're trying to cast.
+ @param typeMetadata_ The `TypeMetadata` you're checking the `Any` against.
+ @return A pointer to the payload that is safe to cast based on the type
+         metadata.
+ */
+const void *_Nonnull trill_checkedCast(TRILL_ANY anyValue_,
+                                       const void *_Nonnull typeMetadata_);
+
+
+/**
+ Determines if the value underlying an `Any` is `nil`. If the type underlying
+ the `Any` is not a pointer or indirect type, then this will always return
+ `false`. However, if the underlying value is a pointer or indirect type, then
+ this function will read the payload and see if the value in the payload is
+ `NULL`.
+
+ @param any_ The `Any` you're checking.
+ @return A non-zero value if the underlying payload should be interpreted as a
+         `nil` value.
+ */
 uint8_t trill_anyIsNil(TRILL_ANY any_);
+
 
 #ifdef __cplusplus
 }

--- a/Sources/Runtime/metadata.h
+++ b/Sources/Runtime/metadata.h
@@ -22,8 +22,8 @@ extern "C" {
 
 
 /**
- `TRILL_ANY` is a special type understood by the Trill compiler as the
- representation of an `Any` value.
+ \c TRILL_ANY is a special type understood by the Trill compiler as the
+ representation of an \c Any value.
  */
 typedef struct TRILL_ANY {
   void * _Nonnull _any;
@@ -76,11 +76,11 @@ uint64_t trill_getNumFields(const void *_Nonnull typeMeta);
 
 
 /**
- Gets the `FieldMetadata` associated with the provided field index into the
- provided `TypeMetadata`.
+ Gets the \c FieldMetadata associated with the provided field index into the
+ provided \c TypeMetadata.
  
  @note This function will abort if the field index is out of bounds. Ensure
-       the field you pass in is in-bounds by calling `trill_getNumFields` and
+       the field you pass in is in-bounds by calling \c trill_getNumFields and
        comparing the result.
 
  @param typeMeta The type metadata.
@@ -91,7 +91,7 @@ const void *_Nonnull trill_getFieldMetadata(const void *_Nonnull typeMeta,
 
 
 /**
- Gets the name of the provided `FieldMetadata`.
+ Gets the name of the provided \c FieldMetadata.
 
  @param fieldMeta The field metadata.
  @return A constant C string with the field's name as declared in the source.
@@ -100,7 +100,7 @@ const char *_Nonnull trill_getFieldName(const void *_Nonnull fieldMeta);
 
 
 /**
- Gets the `TypeMetadata` of the provided `FieldMetadata`.
+ Gets the \c TypeMetadata of the provided \c FieldMetadata.
 
  @param fieldMeta The field metadata.
  @return The metadata of the field's type.
@@ -118,44 +118,44 @@ size_t trill_getFieldOffset(const void *_Nullable fieldMeta);
 
 
 /**
- Creates an `Any` representation with the provided type metadata.
- An `Any` in Trill is a variable-sized, heap-allocated box that holds:
+ Creates an \c Any representation with the provided type metadata.
+ An \c Any in Trill is a variable-sized, heap-allocated box that holds:
 
  - Type metadata for the underlying object, and
  - A payload that is the size specified in the metadata.
  
  @note This value is uninitialized, and the payload will be empty. You
        must initialize the payload with a value by casting and storing
-       the value into the pointer returned by `trill_getAnyValuePtr`.
+       the value into the pointer returned by \c trill_getAnyValuePtr.
 
  @param typeMeta The type metadata for the underlying value.
- @return A new `Any` box that is uninitialized.
+ @return A new \c Any box that is uninitialized.
  */
 TRILL_ANY trill_allocateAny(const void *_Nonnull typeMeta);
 
 
 /**
- Copies an `Any` if the underlying value's semantics mean it should be copied.
- If the underlying value is a reference type, then the provided `Any` is just
+ Copies an \c Any if the underlying value's semantics mean it should be copied.
+ If the underlying value is a reference type, then the provided \c Any is just
  returned unmodified.
 
- @param any The `Any` you wish to copy.
- @return A new `Any` containing the contents of the old `Any`, if the
+ @param any The \c Any you wish to copy.
+ @return A new \c Any containing the contents of the old \c Any, if the
          underlying value is has value semantics. Otherwise, the provided
-         `Any`.
+         \c Any.
  */
 TRILL_ANY trill_copyAny(TRILL_ANY any);
 
 /**
- Gets a pointer to a field inside the `Any` structure. Specifically, this
+ Gets a pointer to a field inside the \c Any structure. Specifically, this
  is a pointer inside the payload that will, when stored, update the value
  inside the payload.
 
  @note This function will abort if the field index is out of bounds. Ensure
-       the field you pass in is in-bounds by calling `trill_getNumFields` and
+       the field you pass in is in-bounds by calling \c trill_getNumFields and
        comparing the result.
 
- @param any_ The `Any` you're inspecting.
+ @param any_ The \c Any you're inspecting.
  @param fieldNum The field index you're accessing.
  @return A pointer into the payload that points to the value of the
          provided field.
@@ -164,26 +164,26 @@ void *_Nonnull trill_getAnyFieldValuePtr(TRILL_ANY any_, uint64_t fieldNum);
 
 
 /**
- Extracts a field from this payload and wraps it in its own `Any` container.
+ Extracts a field from this payload and wraps it in its own \c Any container.
  
 
  @note This function will abort if the field index is out of bounds. Ensure
-       the field you pass in is in-bounds by calling `trill_getNumFields` and
+       the field you pass in is in-bounds by calling \c trill_getNumFields and
        comparing the result.
 
  @param any_ The composite type from which you're extracting a field.
  @param fieldNum The field index.
- @return A new `Any` with a payload that comes from the field's contents.
+ @return A new \c Any with a payload that comes from the field's contents.
  */
 TRILL_ANY trill_extractAnyField(TRILL_ANY any_, uint64_t fieldNum);
 
 
 /**
- Updates a field with the value inside the provided `Any`.
+ Updates a field with the value inside the provided \c Any.
 
- @param any_ The `Any` for the composite type whose field you are replacing.
+ @param any_ The \c Any for the composite type whose field you are replacing.
  @param fieldNum The index of the field to be replaced.
- @param newAny_ The `Any` for the underlying field.
+ @param newAny_ The \c Any for the underlying field.
  */
 void trill_updateAny(TRILL_ANY any_, uint64_t fieldNum, TRILL_ANY newAny_);
 
@@ -194,43 +194,43 @@ void trill_updateAny(TRILL_ANY any_, uint64_t fieldNum, TRILL_ANY newAny_);
  @note This will perform no casting or type checking for you, and should only
        be used opaquely or if you are absolutely sure of the underlying type.
 
- @param anyValue The `Any` whose payload you want to use.
+ @param anyValue The \c Any whose payload you want to use.
  @return A pointer to the payload that can be cast and then loaded from.
  */
 void *_Nonnull trill_getAnyValuePtr(TRILL_ANY anyValue);
 
 
 /**
- Gets the `TypeMetadata` underlying an `Any` box.
+ Gets the \c TypeMetadata underlying an \c Any box.
 
- @param anyValue The `Any` box.
+ @param anyValue The \c Any box.
  @return The underlying type metadata.
  */
 const void *_Nonnull trill_getAnyTypeMetadata(TRILL_ANY anyValue);
 
 
 /**
- Checks if the underlying metadata of an `Any` matches the metadata provided.
+ Checks if the underlying metadata of an \c Any matches the metadata provided.
 
- @param anyValue_ The `Any` whose type you're checking.
- @param typeMetadata_ The `TypeMetadata` you're checking.
- @return A non-zero value if the type metadata underlying the `Any` box
-         is pointer-equal to the provided `TypeMetadata`. Otherwise, 0.
+ @param anyValue_ The \c Any whose type you're checking.
+ @param typeMetadata_ The \c TypeMetadata you're checking.
+ @return A non-zero value if the type metadata underlying the \c Any box
+         is pointer-equal to the provided \c TypeMetadata. Otherwise, 0.
  */
 uint8_t trill_checkTypes(TRILL_ANY anyValue_,
                          const void *_Nonnull typeMetadata_);
 
 
 /**
- Checks if the underlying metadata of an `Any` box matches the provided
+ Checks if the underlying metadata of an \c Any box matches the provided
  metadata, and returns a pointer to the underlying payload if they do.
  
- @note If the `Any` value does not match the provided metadata, then this
+ @note If the \c Any value does not match the provided metadata, then this
        function causes a fatal error with a descriptive message and then
        aborts with a stack trace.
 
- @param anyValue_ The `Any` you're trying to cast.
- @param typeMetadata_ The `TypeMetadata` you're checking the `Any` against.
+ @param anyValue_ The \c Any you're trying to cast.
+ @param typeMetadata_ The \c TypeMetadata you're checking the \c Any against.
  @return A pointer to the payload that is safe to cast based on the type
          metadata.
  */
@@ -239,15 +239,15 @@ const void *_Nonnull trill_checkedCast(TRILL_ANY anyValue_,
 
 
 /**
- Determines if the value underlying an `Any` is `nil`. If the type underlying
- the `Any` is not a pointer or indirect type, then this will always return
- `false`. However, if the underlying value is a pointer or indirect type, then
+ Determines if the value underlying an \c Any is \c nil. If the type underlying
+ the \c Any is not a pointer or indirect type, then this will always return
+ \c false. However, if the underlying value is a pointer or indirect type, then
  this function will read the payload and see if the value in the payload is
- `NULL`.
+ \c NULL.
 
- @param any_ The `Any` you're checking.
+ @param any_ The \c Any you're checking.
  @return A non-zero value if the underlying payload should be interpreted as a
-         `nil` value.
+         \c nil value.
  */
 uint8_t trill_anyIsNil(TRILL_ANY any_);
 

--- a/Sources/Runtime/metadata_private.h
+++ b/Sources/Runtime/metadata_private.h
@@ -11,34 +11,36 @@
 
 #include "metadata.h"
 
-typedef struct FieldMetadata {
-    const char *name;
-    const void *type;
-    size_t offset;
-} FieldMetadata;
+struct TypeMetadata;
 
-typedef struct TypeMetadata {
+struct FieldMetadata {
     const char *name;
-    const void *fields;
+    const TypeMetadata *typeMetadata;
+    const size_t offset;
+};
+
+struct TypeMetadata {
+    const char *name;
+    const FieldMetadata *fields;
     uint8_t isReferenceType;
     uint64_t sizeInBits;
     uint64_t fieldCount;
     uint64_t pointerLevel;
-} TypeMetadata;
+};
 
-typedef struct ProtocolMetadata {
+struct ProtocolMetadata {
     const char *name;
     const char **methodNames;
-    size_t methodCount;
-} ProtocolMetadata;
+    const size_t methodCount;
+};
 
-typedef struct AnyBox {
-    void *typeMetadata;
-} AnyBox;
+struct AnyBox {
+  const TypeMetadata *typeMetadata;
+};
 
-typedef struct GenericBox {
-    void *typeMetadata;
-    void *witnessTable;
-} GenericBox;
+struct GenericBox {
+    const TypeMetadata *typeMetadata;
+    const void **witnessTable;
+};
 
 #endif /* metadata_private_h */

--- a/Sources/Runtime/runtime.h
+++ b/Sources/Runtime/runtime.h
@@ -20,7 +20,7 @@ extern "C" {
 #define trill_assert(x)                               \
     ({                                                \
       if (!(x)) {                                     \
-          trill_fatalError(": assertion failed: "#x); \
+          trill_fatalError("assertion failed: "#x); \
       }                                               \
     })
 

--- a/trill.xcodeproj/project.pbxproj
+++ b/trill.xcodeproj/project.pbxproj
@@ -1271,7 +1271,7 @@
 					};
 				};
 			};
-			buildConfigurationList = DC8EBA551E5FCEF800AE577C /* Build configuration list for PBXProject "Trill" */;
+			buildConfigurationList = DC8EBA551E5FCEF800AE577C /* Build configuration list for PBXProject "trill" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -1617,6 +1617,7 @@
 				DEVELOPMENT_TEAM = W7GJMYD5A4;
 				HEADER_SEARCH_PATHS = /usr/local/opt/llvm/include;
 				LIBRARY_SEARCH_PATHS = /usr/local/opt/llvm/lib;
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = NO_SWIFTPM;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/Sources/trill/BridgingHeader.h";
@@ -1630,6 +1631,7 @@
 				DEVELOPMENT_TEAM = W7GJMYD5A4;
 				HEADER_SEARCH_PATHS = /usr/local/opt/llvm/include;
 				LIBRARY_SEARCH_PATHS = /usr/local/opt/llvm/lib;
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = NO_SWIFTPM;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/Sources/trill/BridgingHeader.h";
@@ -1656,6 +1658,10 @@
 				INFOPLIST_FILE = trillRuntime/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-Wold-style-cast",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.harlanhaskins.trillRuntime;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1683,6 +1689,10 @@
 				INFOPLIST_FILE = trillRuntime/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-Wold-style-cast",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.harlanhaskins.trillRuntime;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1732,6 +1742,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEVELOPMENT_TEAM = W7GJMYD5A4;
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-Wold-style-cast",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
 			};
@@ -1741,6 +1755,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEVELOPMENT_TEAM = W7GJMYD5A4;
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-Wold-style-cast",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
 			};
@@ -1749,7 +1767,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		DC8EBA551E5FCEF800AE577C /* Build configuration list for PBXProject "Trill" */ = {
+		DC8EBA551E5FCEF800AE577C /* Build configuration list for PBXProject "trill" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DC8EBA5F1E5FCEF800AE577C /* Debug */,


### PR DESCRIPTION
- Removed C-style casts in favor of `reinterpret_cast`
- Added documentation comments to the public metadata functions.
- Added `const` qualifiers to all types that can be `const`.
- Re-declared structs as C++-style structs if they don't need to be visible from Trill.
- Explicitly specified types inside those structs instead of `void *`.