### PR TITLE
[stdlib] Changed methods in Mirror to computed properties

### DIFF
--- a/Sources/Base/Types.swift
+++ b/Sources/Base/Types.swift
@@ -192,9 +192,9 @@ class TypeDecl: Decl {
   let deinitializer: DeinitializerDecl?
   
   func indexOfProperty(named name: Identifier) -> Int? {
-    return properties.index { property in
-      property.name == name
-    }
+    return properties.lazy
+                     .filter { !$0.isComputed }
+                     .index { $0.name == name }
   }
   
   func addInitializer(_ decl: InitializerDecl) {

--- a/Sources/Runtime/metadata.cpp
+++ b/Sources/Runtime/metadata.cpp
@@ -23,12 +23,17 @@ uint64_t trill_getTypeSizeInBits(const void *typeMeta) {
   return reinterpret_cast<const TypeMetadata *>(typeMeta)->sizeInBits;
 }
 
+uint64_t trill_getTypePointerLevel(const void *_Nonnull typeMeta) {
+  trill_assert(typeMeta != nullptr);
+  return reinterpret_cast<const TypeMetadata *>(typeMeta)->pointerLevel;
+}
+
 uint8_t trill_isReferenceType(const void *typeMeta) {
   trill_assert(typeMeta != nullptr);
   return reinterpret_cast<const TypeMetadata *>(typeMeta)->isReferenceType;
 }
 
-uint64_t trill_getNumFields(const void *typeMeta) {
+uint64_t trill_getTypeFieldCount(const void *typeMeta) {
   trill_assert(typeMeta != nullptr);
   return reinterpret_cast<const TypeMetadata *>(typeMeta)->fieldCount;
 }

--- a/Sources/Runtime/metadata.h
+++ b/Sources/Runtime/metadata.h
@@ -43,6 +43,13 @@ typedef struct TRILL_ANY {
  */
 const char *_Nonnull trill_getTypeName(const void *_Nonnull typeMeta);
 
+/**
+ Gets the pointer level of a given type metadata object.
+
+ @param typeMeta The type metadata.
+ @return The pointer level of this metadata.
+ */
+uint64_t trill_getTypePointerLevel(const void *_Nonnull typeMeta);
 
 /**
  Gets the size of type metadata in bits. This takes into account the specific
@@ -72,7 +79,7 @@ uint8_t trill_isReferenceType(const void *_Nonnull typeMeta);
  @param typeMeta The type metadata.
  @return The number of fields in this type.
  */
-uint64_t trill_getNumFields(const void *_Nonnull typeMeta);
+uint64_t trill_getTypeFieldCount(const void *_Nonnull typeMeta);
 
 
 /**
@@ -80,7 +87,7 @@ uint64_t trill_getNumFields(const void *_Nonnull typeMeta);
  provided \c TypeMetadata.
  
  @note This function will abort if the field index is out of bounds. Ensure
-       the field you pass in is in-bounds by calling \c trill_getNumFields and
+       the field you pass in is in-bounds by calling \c trill_getTypeFieldCount and
        comparing the result.
 
  @param typeMeta The type metadata.
@@ -152,7 +159,7 @@ TRILL_ANY trill_copyAny(TRILL_ANY any);
  inside the payload.
 
  @note This function will abort if the field index is out of bounds. Ensure
-       the field you pass in is in-bounds by calling \c trill_getNumFields and
+       the field you pass in is in-bounds by calling \c trill_getTypeFieldCount and
        comparing the result.
 
  @param any_ The \c Any you're inspecting.
@@ -168,7 +175,7 @@ void *_Nonnull trill_getAnyFieldValuePtr(TRILL_ANY any_, uint64_t fieldNum);
  
 
  @note This function will abort if the field index is out of bounds. Ensure
-       the field you pass in is in-bounds by calling \c trill_getNumFields and
+       the field you pass in is in-bounds by calling \c trill_getTypeFieldCount and
        comparing the result.
 
  @param any_ The composite type from which you're extracting a field.

--- a/examples/protocol.tr
+++ b/examples/protocol.tr
@@ -8,7 +8,7 @@ type Bar: Debuggable {
   }
 
   func debugDescription() -> String {
-    return String(cString: Mirror(reflecting: self).name())
+    return String(cString: Mirror(reflecting: self).name)
   }
 }
 

--- a/examples/protocol.tr
+++ b/examples/protocol.tr
@@ -8,7 +8,7 @@ type Bar: Debuggable {
   }
 
   func debugDescription() -> String {
-    return String(cString: Mirror(reflecting: self).name)
+    return String(cString: Mirror(reflecting: self).typeName)
   }
 }
 

--- a/stdlib/Mirror.tr
+++ b/stdlib/Mirror.tr
@@ -14,16 +14,24 @@ type Mirror {
     self._metadata = typeMeta
   }
 
-  func name() -> *Int8 {
+  var typeName: *Int8 {
     return trill_getTypeName(self._metadata)
   }
 
-  func sizeInBits() -> Int {
+  var sizeInBits: Int {
     return trill_getTypeSizeInBits(self._metadata) as Int
   }
 
-  func isReferenceType() -> Bool {
+  var pointerLevel: Int {
+    return trill_getTypePointerLevel(self._metadata) as Int
+  }
+
+  var isReferenceType: Bool {
     return trill_isReferenceType(self._metadata) != 0
+  }
+
+  var fieldCount: Int {
+    return trill_getTypeFieldCount(self._metadata) as Int
   }
 
   func child(_ index: Int) -> Any {
@@ -35,8 +43,8 @@ type Mirror {
   }
 
   func set(value: Any, forKey name: *Int8) {
-    for var i = 0; i < self.numberOfFields(); i += 1 {
-      if strcmp(self.field(at: i).name(), name) == 0 {
+    for var i = 0; i < self.fieldCount; i += 1 {
+      if strcmp(self.field(at: i).name, name) == 0 {
         self.set(value: value, forChild: i)
         return
       }
@@ -49,16 +57,16 @@ type Mirror {
       puts("Metadata is null!\n");
       return;
     }
-    printf("Metadata for type %s (size: %d):\n", self.name(), self.sizeInBits());
-    for var i = 0; i < self.numberOfFields(); i += 1 {
+    printf("Metadata for type %s (size: %d):\n", self.typeName, self.sizeInBits);
+    for var i = 0; i < self.fieldCount; i += 1 {
       let field = self.field(at: i)
       printf("└ ")
-      let name = field.name()
-      printf("(offset %d) ", field.offset())
+      let name = field.name
+      printf("(offset %d) ", field.offset)
       if name != nil {
         printf("%s: ", name)
       }
-      printf("%s\n", field.typeMetadata().name());
+      printf("%s\n", field.typeMetadata.typeName);
 
       // println(self.child(i))
     }
@@ -69,15 +77,20 @@ type Mirror {
       fprintf(file, "nil")
       return
     }
-    fprintf(file, "%s(", self.name())
-    for var i = 0; i < self.numberOfFields(); i += 1 {
+    if self.pointerLevel > 0 {
+      fprintf(file, "%p as %s",
+              *(trill_getAnyValuePtr(self.value) as **Void),
+              self.typeName)
+      return
+    }
+    fprintf(file, "%s(", self.typeName)
+    for var i = 0; i < self.fieldCount; i += 1 {
       let field = self.field(at: i)
       if i != 0 { fprintf(file, ", ") }
-      let name = field.name()
+      let name = field.name
       if name == nil { // tuple
         fprintf(file, ".%d: ", i)
-      }
-      else {
+      } else {
         fprintf(file, "%s: ", name)
       }
       print(self.child(i))
@@ -88,9 +101,6 @@ type Mirror {
   func field(at index: Int) -> FieldMirror {
     return FieldMirror(reflecting: trill_getFieldMetadata(self._metadata, index as UInt))
   }
-  func numberOfFields() -> Int {
-    return trill_getNumFields(self._metadata) as Int
-  }
 }
 
 type FieldMirror {
@@ -98,13 +108,13 @@ type FieldMirror {
   init(reflecting field: FieldMetadata) {
     self._metadata = field
   }
-  func name() -> *Int8 {
+  var name: *Int8 {
     return trill_getFieldName(self._metadata)
   }
-  func typeMetadata() -> Mirror {
+  var typeMetadata: Mirror {
     return Mirror(reflectingType: trill_getFieldType(self._metadata))
   }
-  func offset() -> Int {
+  var offset: Int {
     return trill_getFieldOffset(self._metadata)
   }
 }

--- a/stdlib/print.tr
+++ b/stdlib/print.tr
@@ -3,6 +3,20 @@ func print(_ value: Any) {
     print(value as *Int8)
   } else if value is Int {
     print(value as Int)
+  } else if value is Int8 {
+    print(value as Int8)
+  } else if value is Int16 {
+    print(value as Int16)
+  } else if value is Int32 {
+    print(value as Int32)
+  } else if value is UInt {
+    print(value as UInt)
+  } else if value is UInt8 {
+    print(value as UInt8)
+  } else if value is UInt16 {
+    print(value as UInt16)
+  } else if value is UInt32 {
+    print(value as UInt32)
   } else if value is Bool {
     print(value as Bool)
   } else if value is *Void {
@@ -18,81 +32,65 @@ func print(_ value: Any) {
   }
 }
 
+func putchar(_ value: Int8) {
+  putchar(value as Int32)
+}
+
 func println(_ value: Any) {
   print(value)
-  putchar(10)
+  putchar('\n')
 }
 
 func print(_ string: String) {
     print(string.cString())
 }
 
-func println(_ string: String) {
-    println(string.cString())
-}
-
 func print(_ string: *Int8) {
     printf("%s", string)
-}
-
-func println(_ string: *Int8) {
-    printf("%s\n", string)
 }
 
 func print(_ bool: Bool) {
     printf("%s", bool ? "true" : "false")
 }
 
-func println(_ bool: Bool) {
-    printf("%s\n", bool ? "true" : "false")
-}
-
 func print(_ int: Int) {
     printf("%d", int)
-}
-
-func println(_ int: Int) {
-    printf("%d\n", int)
 }
 
 func print(_ int: Int8) {
     printf("%c", int)
 }
 
-func println(_ int: Int8) {
-    printf("%c\n", int)
-}
-
 func print(_ int: Int16) {
     printf("%d", int)
-}
-
-func println(_ int: Int16) {
-    printf("%d\n", int)
 }
 
 func print(_ int: Int32) {
     printf("%d", int)
 }
 
-func println(_ int: Int32) {
-    printf("%d\n", int)
+func print(_ int: UInt) {
+    printf("%u", int)
+}
+
+func print(_ int: UInt8) {
+    printf("%u", int)
+}
+
+func print(_ int: UInt16) {
+    printf("%d", int)
+}
+
+func print(_ int: UInt32) {
+    printf("%u", int)
 }
 
 func print(_ float: Float) {
     printf("%f", float)
 }
 
-func println(_ float: Float) {
-    printf("%f\n", float)
-}
-
 func print(_ double: Double) {
     printf("%f", double)
-}
-
-func println(_ double: Double) {
-    printf("%f\n", double)
 }
 
 func print(_ array: AnyArray) {

--- a/stdlib/print.tr
+++ b/stdlib/print.tr
@@ -32,13 +32,9 @@ func print(_ value: Any) {
   }
 }
 
-func putchar(_ value: Int8) {
-  putchar(value as Int32)
-}
-
 func println(_ value: Any) {
   print(value)
-  putchar('\n')
+  putchar('\n' as Int32)
 }
 
 func print(_ string: String) {


### PR DESCRIPTION
Also fixes a bug when resolving a pointer to a function that uses a computed property.