### PR TITLE
Separate parsing generics from parsing function signatures

### DIFF
--- a/Sources/Base/Functions.swift
+++ b/Sources/Base/Functions.swift
@@ -227,18 +227,15 @@ class ParamDecl: VarAssignDecl {
 
 class ClosureExpr: Expr {
   let args: [ParamDecl]
-  let genericParams: [GenericParamDecl]
   let returnType: TypeRefExpr
   let body: CompoundStmt
   
   private(set) var captures = Set<ASTNode>()
 
   init(args: [ParamDecl],
-       genericParams: [GenericParamDecl],
        returnType: TypeRefExpr,
        body: CompoundStmt,
        sourceRange: SourceRange? = nil) {
-    self.genericParams = genericParams
     self.args = args
     self.returnType = returnType
     self.body = body

--- a/Sources/Parse/FunctionParser.swift
+++ b/Sources/Parse/FunctionParser.swift
@@ -70,7 +70,10 @@ extension Parser {
     // Deinitializers don't have arguments or return types.
     if case .deinitializer = kind {
     } else {
-      (genericArgs, args, returnType, hasVarArgs) = try parseFuncSignature()
+      if case .operator(.lessThan) = peek() {
+        genericArgs = try parseGenericParamDecls()
+      }
+      (args, returnType, hasVarArgs) = try parseFuncSignature()
     }
 
     // Try to parse a body.
@@ -146,13 +149,7 @@ extension Parser {
     }
   }
   
-  func parseFuncSignature() throws -> (genericArgs: [GenericParamDecl], args: [ParamDecl], ret: TypeRefExpr, hasVarArgs: Bool) {
-    var genericArgs = [GenericParamDecl]()
-
-    if case .operator(.lessThan) = peek() {
-      genericArgs = try parseGenericParamDecls()
-    }
-
+  func parseFuncSignature() throws -> (args: [ParamDecl], ret: TypeRefExpr, hasVarArgs: Bool) {
     try consume(.leftParen)
     var hasVarArgs = false
     var args = [ParamDecl]()
@@ -207,7 +204,7 @@ extension Parser {
     } else {
       returnType = TypeRefExpr(type: .void, name: "Void")
     }
-    return (genericArgs: genericArgs, args: args, ret: returnType, hasVarArgs: hasVarArgs)
+    return (args: args, ret: returnType, hasVarArgs: hasVarArgs)
   }
 
   func parseGenericParamDecls() throws -> [GenericParamDecl] {

--- a/Sources/Parse/ValueParser.swift
+++ b/Sources/Parse/ValueParser.swift
@@ -127,12 +127,11 @@ extension Parser {
       }
     case .leftBrace:
       consumeToken()
-      let (genericParams, args, ret, _) = try parseFuncSignature()
+      let (args, ret, _) = try parseFuncSignature()
       try consume(.in)
       let exprs = try parseStatements(terminators: [.rightBrace])
       consumeToken()
       valExpr = ClosureExpr(args: args,
-                            genericParams: genericParams,
                             returnType: ret,
                             body: CompoundStmt(stmts: exprs),
                             sourceRange: range(start: startLoc))


### PR DESCRIPTION
Bans introducing type variables in closure signatures.