### PR TITLE
Start Solving For Type Variables (Locally)

### DIFF
--- a/Sources/Base/ASTContext.swift
+++ b/Sources/Base/ASTContext.swift
@@ -289,16 +289,16 @@ public class ASTContext {
     switch expr.semanticsProvidingExpr {
     case let expr as NumExpr:
       if case .int = canTy {
-        expr.type = contextualType
+        expr.type = canTy
         return true
       }
       if case .floating = canTy {
-        expr.type = contextualType
+        expr.type = canTy
         return true
       }
     case let expr as ArrayExpr:
       guard case .array(_, let length)? = expr.type else { return false }
-      guard case .array(let ctx, _) = contextualType else {
+      guard case .array(let ctx, _) = canTy else {
         return false
       }
       var changed = false
@@ -312,12 +312,12 @@ public class ASTContext {
     case let expr as InfixOperatorExpr:
       if expr.lhs is NumExpr,
         expr.rhs is NumExpr {
-        var changed = propagateContextualType(contextualType, to: expr.lhs)
-        changed = changed || propagateContextualType(contextualType, to: expr.rhs)
+        var changed = propagateContextualType(canTy, to: expr.lhs)
+        changed = changed || propagateContextualType(canTy, to: expr.rhs)
         return changed
       }
     case let expr as NilExpr where canBeNil(canTy):
-      expr.type = contextualType
+      expr.type = canTy
       return true
     case let expr as TupleExpr:
       guard
@@ -331,12 +331,12 @@ public class ASTContext {
         }
       }
       if changed {
-        expr.type = contextualType
+        expr.type = canTy
       }
       return changed
     case let expr as TernaryExpr:
       if case .any = canTy {
-        expr.type = contextualType
+        expr.type = canTy
         return true
       } else if propagateContextualType(contextualType, to: expr.trueCase) && propagateContextualType(contextualType, to: expr.falseCase) {
         expr.type = contextualType
@@ -344,12 +344,12 @@ public class ASTContext {
       }
     case let expr as StringExpr:
       if [.string, .pointer(type: DataType.int8)].contains(canTy) {
-        expr.type = contextualType
+        expr.type = canTy
         return true
       }
     case let expr as ClosureExpr:
       if case let .function(_, retTy) = canTy {
-        expr.type = contextualType
+        expr.type = canTy
         expr.returnType = TypeRefExpr(type: retTy, name: Identifier(name: ""))
         return true
       }

--- a/Sources/Base/ASTContext.swift
+++ b/Sources/Base/ASTContext.swift
@@ -155,7 +155,7 @@ public class ASTContext {
         ])
       return
     }
-    guard case .function(let args, let ret) = main.type else { fatalError() }
+    guard case .function(let args, let ret) = main.type! else { fatalError() }
     var flags = MainFuncFlags()
     if ret == .int64 {
       _ = flags.insert(.exitCode)
@@ -169,7 +169,7 @@ public class ASTContext {
     let hasInvalidArgs = !args.isEmpty && !flags.contains(.args)
     let hasInvalidRet = ret != .void && !flags.contains(.exitCode)
     if hasInvalidRet || hasInvalidArgs {
-      error(ASTError.invalidMain(got: main.type),
+      error(ASTError.invalidMain(got: main.type!),
             loc: main.startLoc,
             highlights: [
               main.name.range
@@ -257,7 +257,7 @@ public class ASTContext {
           continue search
         }
         var valType = canonicalType(valSugaredType)
-        let candType = canonicalType(candArg.type)
+        let candType = canonicalType(candArg.type!)
         // automatically coerce number literals.
         if propagateContextualType(candType, to: exprArg.val) {
           valType = candType
@@ -396,14 +396,14 @@ public class ASTContext {
   
   @discardableResult
   func add(_ typeDecl: TypeDecl) -> Bool {
-    guard decl(for: typeDecl.type) == nil else {
+    guard decl(for: typeDecl.type!) == nil else {
       error(ASTError.duplicateType(name: typeDecl.name),
             loc: typeDecl.startLoc,
             highlights: [ typeDecl.name.range ])
       return false
     }
     types.append(typeDecl)
-    typeDeclMap[typeDecl.type] = typeDecl
+    typeDeclMap[typeDecl.type!] = typeDecl
     return true
   }
   
@@ -525,9 +525,9 @@ public class ASTContext {
   func containsInLayout(type: DataType, typeDecl: TypeDecl, base: Bool = false) -> Bool {
     if !base && matchRank(typeDecl.type, type) != nil { return true }
     for property in typeDecl.properties {
-      if case .pointer = property.type { continue }
+      if case .pointer = property.type! { continue }
       if property.isComputed { continue }
-      if let decl = decl(for: property.type),
+      if let decl = decl(for: property.type!),
         !decl.isIndirect,
         containsInLayout(type: type, typeDecl: decl) {
         return true
@@ -537,7 +537,7 @@ public class ASTContext {
   }
   
   func isCircularType(_ typeDecl: TypeDecl) -> Bool {
-    return containsInLayout(type: typeDecl.type, typeDecl: typeDecl, base: true)
+    return containsInLayout(type: typeDecl.type!, typeDecl: typeDecl, base: true)
   }
   
   func matchRank(_ type1: DataType?, _ type2: DataType?) -> TypeRank? {

--- a/Sources/Base/ASTContext.swift
+++ b/Sources/Base/ASTContext.swift
@@ -347,6 +347,12 @@ public class ASTContext {
         expr.type = contextualType
         return true
       }
+    case let expr as ClosureExpr:
+      if case let .function(_, retTy) = canTy {
+        expr.type = contextualType
+        expr.returnType = TypeRefExpr(type: retTy, name: Identifier(name: ""))
+        return true
+      }
     default:
       break
     }

--- a/Sources/Base/ASTTransformer.swift
+++ b/Sources/Base/ASTTransformer.swift
@@ -73,14 +73,14 @@ class ASTTransformer: ASTVisitor {
     context.extensions.forEach(visitExtensionDecl)
   }
   
-  func matchRank(_ t1: DataType?, _ t2: DataType?) -> TypeRank? {
+  func matchRank(_ t1: DataType, _ t2: DataType) -> TypeRank? {
     return context.matchRank(t1, t2)
   }
-  
-  func matches(_ t1: DataType?, _ t2: DataType?) -> Bool {
-    return matchRank(t1, t2) != nil
+
+  func matches(_ t1: DataType, _ t2: DataType) -> Bool {
+    return context.matches(t1, t2)
   }
-  
+
   func visitNumExpr(_ expr: NumExpr) {}
   func visitCharExpr(_ expr: CharExpr) {}
   func visitFloatExpr(_ expr: FloatExpr) {}

--- a/Sources/Base/Functions.swift
+++ b/Sources/Base/Functions.swift
@@ -67,15 +67,18 @@ class FuncDecl: Decl { // func <id>(<id>: <type-id>) -> <type-id> { <expr>* }
     self.isPlaceholder = isPlaceholder
     var allValid = true
     for arg in args {
-      if arg.type == nil {
+      if case .error = arg.type {
         allValid = false
         break
       }
     }
-    super.init(type: .function(args: allValid ? args.map { $0.type! } : [], returnType: returnType.type!),
+    super.init(type: .function(args: allValid ? args.map { $0.type } : [],
+                               returnType: returnType.type,
+                               hasVarArgs: hasVarArgs),
                modifiers: modifiers,
                sourceRange: sourceRange)
   }
+  
   var formattedParameterList: String {
     var s = "("
     for (idx, arg) in args.enumerated() where !arg.isImplicitSelf {
@@ -89,7 +92,7 @@ class FuncDecl: Decl { // func <id>(<id>: <type-id>) -> <type-id> { <expr>* }
         names.append(arg.name.name)
       }
       s += names.joined(separator: " ")
-      s += ": \(arg.type!)"
+      s += ": \(arg.type)"
       if idx != args.count - 1 || hasVarArgs {
         s += ", "
       }
@@ -105,7 +108,7 @@ class FuncDecl: Decl { // func <id>(<id>: <type-id>) -> <type-id> { <expr>* }
     s += formattedParameterList
     if returnType != .void {
       s += " -> "
-      s += "\(returnType.type!)"
+      s += "\(returnType.type)"
     }
     return s
   }

--- a/Sources/Base/Functions.swift
+++ b/Sources/Base/Functions.swift
@@ -65,7 +65,14 @@ class FuncDecl: Decl { // func <id>(<id>: <type-id>) -> <type-id> { <expr>* }
     self.returnType = returnType
     self.hasVarArgs = hasVarArgs
     self.isPlaceholder = isPlaceholder
-    super.init(type: .function(args: args.map { $0.type }, returnType: returnType.type!),
+    var allValid = true
+    for arg in args {
+      if arg.type == nil {
+        allValid = false
+        break
+      }
+    }
+    super.init(type: .function(args: allValid ? args.map { $0.type! } : [], returnType: returnType.type!),
                modifiers: modifiers,
                sourceRange: sourceRange)
   }
@@ -82,7 +89,7 @@ class FuncDecl: Decl { // func <id>(<id>: <type-id>) -> <type-id> { <expr>* }
         names.append(arg.name.name)
       }
       s += names.joined(separator: " ")
-      s += ": \(arg.type)"
+      s += ": \(arg.type!)"
       if idx != args.count - 1 || hasVarArgs {
         s += ", "
       }
@@ -216,7 +223,7 @@ class ParamDecl: VarAssignDecl {
   var isImplicitSelf = false
   let externalName: Identifier?
   init(name: Identifier,
-       type: TypeRefExpr,
+       type: TypeRefExpr?,
        externalName: Identifier? = nil,
        rhs: Expr? = nil,
        sourceRange: SourceRange? = nil) {
@@ -227,13 +234,13 @@ class ParamDecl: VarAssignDecl {
 
 class ClosureExpr: Expr {
   let args: [ParamDecl]
-  var returnType: TypeRefExpr
+  var returnType: TypeRefExpr?
   let body: CompoundStmt
   
   private(set) var captures = Set<ASTNode>()
 
   init(args: [ParamDecl],
-       returnType: TypeRefExpr,
+       returnType: TypeRefExpr?,
        body: CompoundStmt,
        sourceRange: SourceRange? = nil) {
     self.args = args

--- a/Sources/Base/Functions.swift
+++ b/Sources/Base/Functions.swift
@@ -227,7 +227,7 @@ class ParamDecl: VarAssignDecl {
 
 class ClosureExpr: Expr {
   let args: [ParamDecl]
-  let returnType: TypeRefExpr
+  var returnType: TypeRefExpr
   let body: CompoundStmt
   
   private(set) var captures = Set<ASTNode>()

--- a/Sources/Base/SourceLocation.swift
+++ b/Sources/Base/SourceLocation.swift
@@ -3,6 +3,8 @@
 //  Trill
 //
 
+import Foundation
+
 struct SourceLocation: CustomStringConvertible {
   let file: String?
   var line: Int
@@ -15,7 +17,13 @@ struct SourceLocation: CustomStringConvertible {
     self.charOffset = charOffset
   }
   var description: String {
-    return "<file: \(file ?? "<none>") line: \(line), col: \(column)>"
+    let basename: String
+    if let file = file {
+      basename = URL(fileURLWithPath: file).lastPathComponent
+    } else {
+      basename = "<none>"
+    }
+    return "<\(basename):\(line):\(column)>"
   }
   static let zero = SourceLocation(line: 0, column: 0)
 }

--- a/Sources/Base/Statements.swift
+++ b/Sources/Base/Statements.swift
@@ -75,6 +75,15 @@ class VarAssignDecl: Decl {
     superAttrs["mutable"] = mutable
     return superAttrs
   }
+
+  override var type: DataType {
+    set {
+      super.type = newValue
+    }
+    get {
+      return self.rhs?.type ?? super.type
+    }
+  }
 }
 
 class CompoundStmt: Stmt {

--- a/Sources/Base/Statements.swift
+++ b/Sources/Base/Statements.swift
@@ -62,7 +62,7 @@ class VarAssignDecl: Decl {
   
   override func attributes() -> [String : Any] {
     var superAttrs = super.attributes()
-    superAttrs["type"] = typeRef?.type?.description
+    superAttrs["type"] = typeRef?.type.description
     superAttrs["name"] = name.name
     superAttrs["kind"] = {
       switch kind {
@@ -166,7 +166,7 @@ class ExtensionDecl: Decl {
     self.subscripts = subscripts
     self.staticMethods = staticMethods
     self.typeRef = type
-    super.init(type: type.type!, modifiers: [], sourceRange: sourceRange)
+    super.init(type: type.type, modifiers: [], sourceRange: sourceRange)
   }
 }
 

--- a/Sources/Base/Statements.swift
+++ b/Sources/Base/Statements.swift
@@ -75,15 +75,6 @@ class VarAssignDecl: Decl {
     superAttrs["mutable"] = mutable
     return superAttrs
   }
-
-  override var type: DataType {
-    set {
-      super.type = newValue
-    }
-    get {
-      return self.rhs?.type ?? super.type
-    }
-  }
 }
 
 class CompoundStmt: Stmt {

--- a/Sources/Base/Types.swift
+++ b/Sources/Base/Types.swift
@@ -83,7 +83,7 @@ enum DataType: CustomStringConvertible, Hashable {
   }
 
   // Occurs
-  func contains(_ x : String) -> Bool {
+  func contains(_ x: String) -> Bool {
     switch self {
     case let .function(args, returnType, _):
       return args.reduce(false, { (acc, t) in acc || t.contains(x) })

--- a/Sources/Base/Values.swift
+++ b/Sources/Base/Values.swift
@@ -10,7 +10,7 @@ enum Promotion {
 }
 
 class Expr: ASTNode {
-  var type: DataType? = nil
+  var type: DataType = .error
   var promotion: Promotion? = nil
 
   /// Looks through syntactic sugar expressions like `ParenExpr` to find the
@@ -21,7 +21,7 @@ class Expr: ASTNode {
 
   override func attributes() -> [String : Any] {
     var attrs = super.attributes()
-    if let type = type {
+    if type != .error {
       attrs["type"] = type.description
     }
     if let promotion = promotion {
@@ -120,7 +120,7 @@ class TupleFieldLookupExpr: Expr {
 }
 
 class FloatExpr: ConstantExpr {
-  override var type: DataType? {
+  override var type: DataType {
     get { return .double } set { }
   }
   let value: Double
@@ -139,7 +139,7 @@ class FloatExpr: ConstantExpr {
 }
 
 class BoolExpr: ConstantExpr {
-  override var type: DataType? {
+  override var type: DataType {
     get { return .bool } set { }
   }
   let value: Bool
@@ -187,7 +187,7 @@ class PoundFunctionExpr: StringExpr {
 class PoundFileExpr: StringExpr {}
 
 class CharExpr: ConstantExpr {
-  override var type: DataType? {
+  override var type: DataType {
     get { return .int8 } set { }
   }
   let value: UInt8

--- a/Sources/IRGen/BaseIRGen.swift
+++ b/Sources/IRGen/BaseIRGen.swift
@@ -396,7 +396,7 @@ class IRGenerator: ASTVisitor, Pass {
   /// - parameters:
   ///   - type: A TypeRefExpr from an expression.
   func resolveLLVMType(_ type: TypeRefExpr) -> IRType {
-    return resolveLLVMType(type.type!)
+    return resolveLLVMType(type.type)
   }
   
   /// Resolves the LLVM type for a given Trill type.
@@ -423,10 +423,12 @@ class IRGenerator: ASTVisitor, Pass {
     case .pointer(let subtype):
       let irType = resolveLLVMType(subtype)
       return PointerType(pointee: irType)
-    case .function(let args, let ret):
+    case .function(let args, let ret, let hasVarArgs):
       let argTypes = args.map(resolveLLVMType)
       let retTy = resolveLLVMType(ret)
-      return PointerType(pointee: FunctionType(argTypes: argTypes, returnType: retTy))
+      return PointerType(pointee: FunctionType(argTypes: argTypes,
+                                               returnType: retTy,
+                                               isVarArg: hasVarArgs))
     case .tuple:
       return codegenTupleType(type)
     case .custom:
@@ -477,7 +479,7 @@ class IRGenerator: ASTVisitor, Pass {
       return VarBinding(ref: function,
                         storage: .reference,
                         read: {
-                          let meta = self.codegenTypeMetadata(decl.type!)
+                          let meta = self.codegenTypeMetadata(decl.type)
                           let arg = self.builder.buildBitCast(meta, type: PointerType(pointee: IntType.int8))
                           return self.builder.buildCall(function, args: [arg])
                         },

--- a/Sources/IRGen/BaseIRGen.swift
+++ b/Sources/IRGen/BaseIRGen.swift
@@ -477,7 +477,7 @@ class IRGenerator: ASTVisitor, Pass {
       return VarBinding(ref: function,
                         storage: .reference,
                         read: {
-                          let meta = self.codegenTypeMetadata(decl.type)
+                          let meta = self.codegenTypeMetadata(decl.type!)
                           let arg = self.builder.buildBitCast(meta, type: PointerType(pointee: IntType.int8))
                           return self.builder.buildCall(function, args: [arg])
                         },

--- a/Sources/IRGen/BuiltinIRGen.swift
+++ b/Sources/IRGen/BuiltinIRGen.swift
@@ -12,9 +12,10 @@ extension IRGenerator {
   func codegenTypeOfCall(_ expr: FuncCallExpr) -> Result {
     guard
       let arg = expr.args.first,
-      let type = arg.val.type else {
+      arg.val.type != .error else {
         return nil
     }
+    let type = arg.val.type
     if case .any = type {
         let getMetadata = codegenIntrinsic(named: "trill_getAnyTypeMetadata")
         return builder.buildCall(getMetadata, args: [visit(arg.val)!], name: "any-binding")

--- a/Sources/IRGen/FunctionIRGen.swift
+++ b/Sources/IRGen/FunctionIRGen.swift
@@ -38,8 +38,8 @@ extension IRGenerator {
     }
     var argTys = [IRType]()
     for arg in expr.args {
-      var type = resolveLLVMType(arg.type!)
-      if arg.isImplicitSelf && storage(for: arg.type!) != .reference {
+      var type = resolveLLVMType(arg.type)
+      if arg.isImplicitSelf && storage(for: arg.type) != .reference {
         type = PointerType(pointee: type)
       }
       argTys.append(type)
@@ -64,9 +64,10 @@ extension IRGenerator {
   }
 
   func synthesizeIntializer(_ decl: InitializerDecl, function: Function) -> IRValue {
+    let type = decl.returnType.type
     guard let body = decl.body,
           body.stmts.isEmpty,
-          let type = decl.returnType.type,
+          type != .error,
           let typeDecl = context.decl(for: type) else {
       fatalError("must synthesize an empty initializer")
     }
@@ -114,7 +115,7 @@ extension IRGenerator {
     
     let entrybb = function.appendBasicBlock(named: "entry", in: llvmContext)
     let retbb = function.appendBasicBlock(named: "return", in: llvmContext)
-    let returnType = decl.returnType.type!
+    let returnType = decl.returnType.type
     let type = resolveLLVMType(decl.returnType)
     var res: VarBinding? = nil
     let storageKind = storage(for: returnType)
@@ -136,8 +137,8 @@ extension IRGenerator {
         var param = function.parameter(at: idx)!
         param.name = arg.name.name
         let type = arg.type
-        let argType = resolveLLVMType(type!)
-        let storageKind = storage(for: type!)
+        let argType = resolveLLVMType(type)
+        let storageKind = storage(for: type)
         let read: () -> IRValue
         if arg.isImplicitSelf && storageKind == .reference {
           read = { param }
@@ -256,7 +257,7 @@ extension IRGenerator {
     var argVals = [IRValue]()
     for (idx, arg) in args.enumerated() {
       var val = visit(arg.val)!
-      var type = arg.val.type!
+      var type = arg.val.type
       if case .array(let field, _) = type {
         let alloca = createEntryBlockAlloca(currentFunction!.functionRef!,
                                             type: val.type,
@@ -291,8 +292,9 @@ extension IRGenerator {
     var store: IRValue? = nil
     if !(expr.value is VoidExpr) {
       var val = visit(expr.value)!
-      if let type = expr.value.type,
-         case .any = context.canonicalType(currentDecl.returnType.type!) {
+      let type = expr.value.type
+      if type != .error,
+         case .any = context.canonicalType(currentDecl.returnType.type) {
         val = codegenPromoteToAny(value: val, type: type)
       }
       if !(currentDecl is InitializerDecl) {

--- a/Sources/IRGen/FunctionIRGen.swift
+++ b/Sources/IRGen/FunctionIRGen.swift
@@ -38,8 +38,8 @@ extension IRGenerator {
     }
     var argTys = [IRType]()
     for arg in expr.args {
-      var type = resolveLLVMType(arg.type)
-      if arg.isImplicitSelf && storage(for: arg.type) != .reference {
+      var type = resolveLLVMType(arg.type!)
+      if arg.isImplicitSelf && storage(for: arg.type!) != .reference {
         type = PointerType(pointee: type)
       }
       argTys.append(type)
@@ -136,8 +136,8 @@ extension IRGenerator {
         var param = function.parameter(at: idx)!
         param.name = arg.name.name
         let type = arg.type
-        let argType = resolveLLVMType(type)
-        let storageKind = storage(for: type)
+        let argType = resolveLLVMType(type!)
+        let storageKind = storage(for: type!)
         let read: () -> IRValue
         if arg.isImplicitSelf && storageKind == .reference {
           read = { param }

--- a/Sources/IRGen/FunctionIRGen.swift
+++ b/Sources/IRGen/FunctionIRGen.swift
@@ -272,7 +272,7 @@ extension IRGenerator {
       }
       argVals.append(val)
     }
-    let name = expr.type == .void ? "" : "calltmp"
+    let name = decl.returnType.type == .void ? "" : "calltmp"
     let call = builder.buildCall(function!, args: argVals, name: name)
     if decl.has(attribute: .noreturn) {
       builder.buildUnreachable()

--- a/Sources/IRGen/StatementIRGen.swift
+++ b/Sources/IRGen/StatementIRGen.swift
@@ -9,7 +9,7 @@ extension IRGenerator {
   @discardableResult
   func codegenGlobalPrototype(_ decl: VarAssignDecl) -> VarBinding {
     if let binding = globalVarIRBindings[decl.name] { return binding }
-    let type = resolveLLVMType(decl.type!)
+    let type = resolveLLVMType(decl.type)
     var global = builder.addGlobal(decl.name.name, type: type)
     global.alignment = 8
     let binding = VarBinding(ref: global,
@@ -39,7 +39,7 @@ extension IRGenerator {
       global.isExternallyInitialized = true
       return binding
     }
-    let irType = resolveLLVMType(decl.type!)
+    let irType = resolveLLVMType(decl.type)
     guard let rhs = decl.rhs else {
       global.initializer = irType.null()
       global.isGlobalConstant = !decl.mutable
@@ -84,15 +84,15 @@ extension IRGenerator {
   
   func visitVarAssignDecl(_ decl: VarAssignDecl) -> Result {
     let function = currentFunction!.functionRef!
-    let type = decl.type!
+    let type = decl.type
     let irType = resolveLLVMType(type)
     var value: IRValue
     if let rhs = decl.rhs, let val = visit(rhs) {
       value = val
       if case .any = type {
-        value = codegenPromoteToAny(value: value, type: rhs.type!)
-      } else if rhs.type! != type {
-        value = coerce(value, from: rhs.type!, to: type)!
+        value = codegenPromoteToAny(value: value, type: rhs.type)
+      } else if rhs.type != type {
+        value = coerce(value, from: rhs.type, to: type)!
       }
     } else {
       value = irType.null()

--- a/Sources/IRGen/StatementIRGen.swift
+++ b/Sources/IRGen/StatementIRGen.swift
@@ -9,7 +9,7 @@ extension IRGenerator {
   @discardableResult
   func codegenGlobalPrototype(_ decl: VarAssignDecl) -> VarBinding {
     if let binding = globalVarIRBindings[decl.name] { return binding }
-    let type = resolveLLVMType(decl.type)
+    let type = resolveLLVMType(decl.type!)
     var global = builder.addGlobal(decl.name.name, type: type)
     global.alignment = 8
     let binding = VarBinding(ref: global,
@@ -39,7 +39,7 @@ extension IRGenerator {
       global.isExternallyInitialized = true
       return binding
     }
-    let irType = resolveLLVMType(decl.type)
+    let irType = resolveLLVMType(decl.type!)
     guard let rhs = decl.rhs else {
       global.initializer = irType.null()
       global.isGlobalConstant = !decl.mutable
@@ -84,7 +84,7 @@ extension IRGenerator {
   
   func visitVarAssignDecl(_ decl: VarAssignDecl) -> Result {
     let function = currentFunction!.functionRef!
-    let type = decl.type
+    let type = decl.type!
     let irType = resolveLLVMType(type)
     var value: IRValue
     if let rhs = decl.rhs, let val = visit(rhs) {

--- a/Sources/IRGen/TypeIRGen.swift
+++ b/Sources/IRGen/TypeIRGen.swift
@@ -17,9 +17,9 @@ extension IRGenerator {
       return existing
     }
     let structure = builder.createStruct(name: expr.name.name)
-    typeIRBindings[expr.type] = structure
+    typeIRBindings[expr.type!] = structure
     let fieldTypes = expr.storedProperties
-                         .map { resolveLLVMType($0.type) }
+                         .map { resolveLLVMType($0.type!) }
     structure.setBody(fieldTypes)
     
     for method in expr.methods + expr.staticMethods {
@@ -107,7 +107,7 @@ extension IRGenerator {
         fatalError("no decl?")
       }
       properties = decl.storedProperties
-                       .map { ($0.name.name, $0.type) }
+                       .map { ($0.name.name, $0.type!) }
     case .tuple(let types):
       properties = types.enumerated().map { (".\($0.offset)", $0.element) }
     default:

--- a/Sources/IRGen/TypeIRGen.swift
+++ b/Sources/IRGen/TypeIRGen.swift
@@ -17,9 +17,9 @@ extension IRGenerator {
       return existing
     }
     let structure = builder.createStruct(name: expr.name.name)
-    typeIRBindings[expr.type!] = structure
+    typeIRBindings[expr.type] = structure
     let fieldTypes = expr.storedProperties
-                         .map { resolveLLVMType($0.type!) }
+                         .map { resolveLLVMType($0.type) }
     structure.setBody(fieldTypes)
     
     for method in expr.methods + expr.staticMethods {
@@ -107,7 +107,7 @@ extension IRGenerator {
         fatalError("no decl?")
       }
       properties = decl.storedProperties
-                       .map { ($0.name.name, $0.type!) }
+                       .map { ($0.name.name, $0.type) }
     case .tuple(let types):
       properties = types.enumerated().map { (".\($0.offset)", $0.element) }
     default:
@@ -231,7 +231,8 @@ extension IRGenerator {
   ///                it doesn't necessarily have a stack variable.
   func resolvePtr(_ expr: Expr) -> IRValue {
     let createTmpPointer: (Expr) -> IRValue = { expr in
-      guard let type = expr.type else { fatalError("unknown type") }
+      let type = expr.type
+      guard type != .error else { fatalError("error type in resolvePtr") }
       let value = self.visit(expr)!
       if case .any = self.context.canonicalType(type) {
         return self.codegenAnyValuePtr(value, type: .pointer(type: .int8))
@@ -262,13 +263,13 @@ extension IRGenerator {
       let lhs = resolvePtr(expr.lhs)
       return builder.buildStructGEP(lhs, index: expr.field, name: "tuple-ptr")
     case let expr as InfixOperatorExpr where expr.op == .as:
-      if let type = expr.type, case .any = context.canonicalType(type) {
-        return codegenAnyValuePtr(visit(expr)!, type: expr.rhs.type!)
+      if case .any = context.canonicalType(expr.type) {
+        return codegenAnyValuePtr(visit(expr)!, type: expr.rhs.type)
       }
       return createTmpPointer(expr)
     case let expr as SubscriptExpr:
       let lhs = visit(expr.lhs)!
-      switch expr.lhs.type! {
+      switch expr.lhs.type {
       case .pointer, .array:
         return builder.buildGEP(lhs, indices: [visit(expr.args[0].val)!],
                                 name: "gep")
@@ -289,7 +290,7 @@ extension IRGenerator {
     }
     var ptr = resolvePtr(expr.lhs)
     let isImplicitSelf = (expr.lhs as? VarExpr)?.isSelf ?? false
-    if case .reference = storage(for: expr.lhs.type!),
+    if case .reference = storage(for: expr.lhs.type),
       !isImplicitSelf {
       ptr = builder.buildLoad(ptr, name: "\(expr.name)-load")
     }

--- a/Sources/IRGen/ValueIRGen.swift
+++ b/Sources/IRGen/ValueIRGen.swift
@@ -22,7 +22,7 @@ extension IRGenerator {
   }
   
   func visitNumExpr(_ expr: NumExpr) -> Result {
-    let llvmTy = resolveLLVMType(expr.type!)
+    let llvmTy = resolveLLVMType(expr.type)
     switch llvmTy {
     case let type as FloatType:
       return type.constant(Double(expr.value))
@@ -38,7 +38,7 @@ extension IRGenerator {
   }
   
   func visitFloatExpr(_ expr: FloatExpr) -> Result {
-    guard let type = resolveLLVMType(expr.type!) as? FloatType else {
+    guard let type = resolveLLVMType(expr.type) as? FloatType else {
       fatalError("non-float floatexpr?")
     }
     return type.constant(expr.value)
@@ -49,16 +49,16 @@ extension IRGenerator {
   }
   
   func visitArrayExpr(_ expr: ArrayExpr) -> Result {
-    guard case .array(let fieldTy, _)? = expr.type else {
+    guard case .array(let fieldTy, _) = expr.type else {
       fatalError("invalid array type")
     }
-    let irType = resolveLLVMType(expr.type!)
+    let irType = resolveLLVMType(expr.type)
     var initial = irType.null()
     for (idx, value) in expr.values.enumerated() {
       var irValue = visit(value)!
       let index = IntType.int64.constant(idx)
       if case .any = context.canonicalType(fieldTy) {
-        irValue = codegenPromoteToAny(value: irValue, type: value.type!)
+        irValue = codegenPromoteToAny(value: irValue, type: value.type)
       }
       initial = builder.buildInsertElement(vector: initial, element: irValue, index: index)
     }
@@ -66,8 +66,8 @@ extension IRGenerator {
   }
   
   func visitTupleExpr(_ expr: TupleExpr) -> Result {
-    let type = resolveLLVMType(expr.type!)
-    guard case .tuple(let tupleTypes)? = expr.type else {
+    let type = resolveLLVMType(expr.type)
+    guard case .tuple(let tupleTypes) = expr.type else {
       fatalError("invalid tuple type")
     }
     var initial = type.null()
@@ -75,7 +75,7 @@ extension IRGenerator {
       var val = visit(field)!
       let canTupleTy = context.canonicalType(tupleTypes[idx])
       if case .any = canTupleTy {
-        val = codegenPromoteToAny(value: val, type: field.type!)
+        val = codegenPromoteToAny(value: val, type: field.type)
       }
       initial = builder.buildInsertValue(aggregate: initial,
                                          element: val,
@@ -115,7 +115,7 @@ extension IRGenerator {
   }
   
   func visitNilExpr(_ expr: NilExpr) -> Result {
-    let type = resolveLLVMType(expr.type!)
+    let type = resolveLLVMType(expr.type)
     return type.null()
   }
   
@@ -154,7 +154,7 @@ extension IRGenerator {
   
   func visitStringExpr(_ expr: StringExpr) -> Result {
     let globalString = codegenGlobalStringPtr(expr.value)
-    if let type = expr.type, case .pointer(type: DataType.int8) = type {
+    if case .pointer(type: DataType.int8) = expr.type {
       return globalString.ptr
     }
 
@@ -304,19 +304,19 @@ extension IRGenerator {
       let lhs: IRValue
 
       lhs = visit(expr.lhs)!
-      return coerce(lhs, from: expr.lhs.type!, to: expr.type!)
+      return coerce(lhs, from: expr.lhs.type, to: expr.type)
     }
     
     if case .is = expr.op {
       let lhs = visit(expr.lhs)!
-      return codegenTypeCheck(lhs, type: expr.rhs.type!)
+      return codegenTypeCheck(lhs, type: expr.rhs.type)
     }
     
     var rhs = visit(expr.rhs)!
     
     if case .assign = expr.op {
-      if case .any? = expr.lhs.type {
-        rhs = codegenPromoteToAny(value: rhs, type: expr.rhs.type!)
+      if case .any = context.canonicalType(expr.lhs.type) {
+        rhs = codegenPromoteToAny(value: rhs, type: expr.rhs.type)
       }
       if let propRef = expr.lhs as? PropertyRefExpr,
          let propDecl = propRef.decl as? PropertyDecl,
@@ -327,7 +327,7 @@ extension IRGenerator {
       }
       let ptr = resolvePtr(expr.lhs)
       return builder.buildStore(rhs, to: ptr)
-    } else if context.canBeNil(expr.lhs.type!) && expr.rhs is NilExpr {
+    } else if context.canBeNil(expr.lhs.type) && expr.rhs is NilExpr {
       let lhs = visit(expr.lhs)!
       if case .equalTo = expr.op {
         return builder.buildIsNull(lhs)
@@ -337,12 +337,12 @@ extension IRGenerator {
     } else if expr.op.associatedOp != nil {
       let ptr = resolvePtr(expr.lhs)
       let lhsVal = builder.buildLoad(ptr, name: "cmpassignload")
-      let performed = codegen(expr.decl!, lhs: lhsVal, rhs: rhs, type: expr.lhs.type!)!
+      let performed = codegen(expr.decl!, lhs: lhsVal, rhs: rhs, type: expr.lhs.type)!
       return builder.buildStore(performed, to: ptr)
     }
     
     let lhs = visit(expr.lhs)!
-    return codegen(expr.decl!, lhs: lhs, rhs: rhs, type: expr.lhs.type!)
+    return codegen(expr.decl!, lhs: lhs, rhs: rhs, type: expr.lhs.type)
   }
   
   func visitPoundFunctionExpr(_ expr: PoundFunctionExpr) -> Result {
@@ -372,8 +372,7 @@ extension IRGenerator {
   
   func visitTernaryExpr(_ expr: TernaryExpr) -> Result {
     guard let function = currentFunction?.functionRef else { fatalError("no function") }
-    guard let type = expr.type else { fatalError("no ternary type") }
-    let irType = resolveLLVMType(type)
+    let irType = resolveLLVMType(expr.type)
     let cond = visit(expr.condition)!
     let result = createEntryBlockAlloca(function, type: irType,
                                         name: "ternary-result", storage: .value)
@@ -382,11 +381,11 @@ extension IRGenerator {
     let endbb = function.appendBasicBlock(named: "ternary-end", in: llvmContext)
     builder.buildCondBr(condition: cond, then: truebb, else: falsebb)
     builder.positionAtEnd(of: truebb)
-    let trueVal = coerce(visit(expr.trueCase)!, from: expr.trueCase.type!, to: type)!
+    let trueVal = coerce(visit(expr.trueCase)!, from: expr.trueCase.type, to: expr.type)!
     result.write(trueVal)
     builder.buildBr(endbb)
     builder.positionAtEnd(of: falsebb)
-    let falseVal = coerce(visit(expr.falseCase)!, from: expr.falseCase.type!, to: type)!
+    let falseVal = coerce(visit(expr.falseCase)!, from: expr.falseCase.type, to: expr.type)!
     result.write(falseVal)
     builder.buildBr(endbb)
     builder.positionAtEnd(of: endbb)

--- a/Sources/Import/ClangImporter.swift
+++ b/Sources/Import/ClangImporter.swift
@@ -490,7 +490,7 @@ class ClangImporter: Pass {
       guard let expr = try simpleParseCToken(tok, range: range) else { return nil }
 
       return VarAssignDecl(name: Identifier(name: name),
-                           typeRef: expr.type?.ref(),
+                           typeRef: expr.type.ref(),
                            rhs: expr,
                            modifiers: [.implicit],
                            mutable: false,
@@ -674,7 +674,7 @@ class ClangImporter: Pass {
     case CXType_FunctionNoProto:
       let ret = clang_getResultType(type)
       guard let trillRet = convertToTrillType(ret) else { return nil }
-      return .function(args: [], returnType: trillRet)
+      return .function(args: [], returnType: trillRet, hasVarArgs: false)
     case CXType_Typedef:
       let typeDecl = clang_getTypeDeclaration(type)
       let typeName = clang_getCursorSpelling(typeDecl).asSwift()
@@ -713,6 +713,7 @@ class ClangImporter: Pass {
     let ret = clang_getResultType(type)
     let trillRet = convertToTrillType(ret) ?? .void
     let numArgs = clang_getNumArgTypes(type)
+    let isVarArg = clang_isFunctionTypeVariadic(type) != 0
     
     guard numArgs != -1 else { return nil }
     
@@ -722,6 +723,6 @@ class ClangImporter: Pass {
       guard let trillArgTy = convertToTrillType(type) else { return nil }
       args.append(trillArgTy)
     }
-    return .function(args: args, returnType: trillRet)
+    return .function(args: args, returnType: trillRet, hasVarArgs: isVarArg)
   }
 }

--- a/Sources/Parse/FunctionParser.swift
+++ b/Sources/Parse/FunctionParser.swift
@@ -148,6 +148,31 @@ extension Parser {
                       sourceRange: range(start: startLoc))
     }
   }
+
+  func parseShorthandSignature() throws -> [ParamDecl] {
+    var args = [ParamDecl]()
+    while true {
+      let startLoc = sourceLoc
+      let name = try parseIdentifier()
+
+      let tv = DataType.freshTypeVariable
+      guard case let .typeVariable(tyName) = tv else {
+        fatalError("Fresh type variable is not a type variable?")
+      }
+      let arg = ParamDecl(name: name,
+                          type: TypeRefExpr(type: tv, name: Identifier(name: tyName)),
+                          sourceRange: range(start: startLoc))
+
+      args.append(arg)
+      if case .in = peek() {
+        consumeToken()
+        break
+      }
+      try consume(.comma)
+    }
+
+    return args
+  }
   
   func parseFuncSignature() throws -> (args: [ParamDecl], ret: TypeRefExpr, hasVarArgs: Bool) {
     try consume(.leftParen)

--- a/Sources/Parse/FunctionParser.swift
+++ b/Sources/Parse/FunctionParser.swift
@@ -154,13 +154,8 @@ extension Parser {
     while true {
       let startLoc = sourceLoc
       let name = try parseIdentifier()
-
-      let tv = DataType.freshTypeVariable
-      guard case let .typeVariable(tyName) = tv else {
-        fatalError("Fresh type variable is not a type variable?")
-      }
       let arg = ParamDecl(name: name,
-                          type: TypeRefExpr(type: tv, name: Identifier(name: tyName)),
+                          type: nil,
                           sourceRange: range(start: startLoc))
 
       args.append(arg)

--- a/Sources/Parse/ValueParser.swift
+++ b/Sources/Parse/ValueParser.swift
@@ -131,33 +131,25 @@ extension Parser {
         // - { x, y, z, ... in <stmts> }
         let exprs = try parseStatements(terminators: [.rightBrace])
         consumeToken()
-        let tv = DataType.freshTypeVariable
-        guard case let .typeVariable(tyName) = tv else {
-          fatalError("Fresh type variable is not a type variable?")
-        }
         valExpr = ClosureExpr(args: args,
-                              returnType: TypeRefExpr(type: tv, name: Identifier(name: tyName)),
+                              returnType: nil,
                               body: CompoundStmt(stmts: exprs),
                               sourceRange: range(start: startLoc))
-      } else if let (args, ret, _) = try? parseFuncSignature() {
+      } else if let (args, retTy, _) = try? parseFuncSignature() {
         // - { (x : T, y : U, ...) in <stmts> }
         try consume(.in)
         let exprs = try parseStatements(terminators: [.rightBrace])
         consumeToken()
         valExpr = ClosureExpr(args: args,
-                              returnType: ret,
+                              returnType: retTy,
                               body: CompoundStmt(stmts: exprs),
                               sourceRange: range(start: startLoc))
       } else {
         // - { <stmts> }
-        let tv = DataType.freshTypeVariable
-        guard case let .typeVariable(tyName) = tv else {
-          fatalError("Fresh type variable is not a type variable?")
-        }
         let exprs = try parseStatements(terminators: [.rightBrace])
         consumeToken()
         valExpr = ClosureExpr(args: [],
-                              returnType: TypeRefExpr(type: tv, name: Identifier(name: tyName)),
+                              returnType: nil,
                               body: CompoundStmt(stmts: exprs),
                               sourceRange: range(start: startLoc))
       }

--- a/Sources/Parse/ValueParser.swift
+++ b/Sources/Parse/ValueParser.swift
@@ -127,14 +127,40 @@ extension Parser {
       }
     case .leftBrace:
       consumeToken()
-      let (args, ret, _) = try parseFuncSignature()
-      try consume(.in)
-      let exprs = try parseStatements(terminators: [.rightBrace])
-      consumeToken()
-      valExpr = ClosureExpr(args: args,
-                            returnType: ret,
-                            body: CompoundStmt(stmts: exprs),
-                            sourceRange: range(start: startLoc))
+      if let args = try? attempt(try parseShorthandSignature())  {
+        // - { x, y, z, ... in <stmts> }
+        let exprs = try parseStatements(terminators: [.rightBrace])
+        consumeToken()
+        let tv = DataType.freshTypeVariable
+        guard case let .typeVariable(tyName) = tv else {
+          fatalError("Fresh type variable is not a type variable?")
+        }
+        valExpr = ClosureExpr(args: args,
+                              returnType: TypeRefExpr(type: tv, name: Identifier(name: tyName)),
+                              body: CompoundStmt(stmts: exprs),
+                              sourceRange: range(start: startLoc))
+      } else if let (args, ret, _) = try? parseFuncSignature() {
+        // - { (x : T, y : U, ...) in <stmts> }
+        try consume(.in)
+        let exprs = try parseStatements(terminators: [.rightBrace])
+        consumeToken()
+        valExpr = ClosureExpr(args: args,
+                              returnType: ret,
+                              body: CompoundStmt(stmts: exprs),
+                              sourceRange: range(start: startLoc))
+      } else {
+        // - { <stmts> }
+        let tv = DataType.freshTypeVariable
+        guard case let .typeVariable(tyName) = tv else {
+          fatalError("Fresh type variable is not a type variable?")
+        }
+        let exprs = try parseStatements(terminators: [.rightBrace])
+        consumeToken()
+        valExpr = ClosureExpr(args: [],
+                              returnType: TypeRefExpr(type: tv, name: Identifier(name: tyName)),
+                              body: CompoundStmt(stmts: exprs),
+                              sourceRange: range(start: startLoc))
+      }
     default:
       throw Diagnostic.error(ParseError.unexpectedExpression(expected: "value"),
                              loc: currentToken().range.start)

--- a/Sources/Runtime/demangle.cpp
+++ b/Sources/Runtime/demangle.cpp
@@ -42,18 +42,22 @@ bool readType(std::string &str, std::string &out) {
     str.erase(0, 1);
     out += '(';
     std::vector<std::string> argNames;
-    while (str.front() != 'R') {
+    while (str.front() != 'R' && str.front() != 'V') {
       std::string name;
       if (!readType(str, name)) { return false; }
       argNames.push_back(name);
     }
-    str.erase(0, 1);
     for (auto i = 0; i < argNames.size(); ++i) {
       out += argNames[i];
       if (i < argNames.size() - 1) {
         out += ", ";
       }
     }
+    if (str.front() == 'V') {
+      str.erase(0, 1);
+      out += ", ...";
+    }
+    str.erase(0, 1);
     out += ") -> ";
     if (!readType(str, out)) { return false; }
   } else if (str.front() == 'A') {

--- a/Sources/Runtime/runtime.h
+++ b/Sources/Runtime/runtime.h
@@ -20,7 +20,7 @@ extern "C" {
 
 void trill_init();
 
-void trill_once(uint64_t *NONNULL predicate, void (*NONNULL initializer)());
+void trill_once(uint64_t *NONNULL predicate, void (*NONNULL initializer)(void));
     
 void trill_printStackTrace();
   

--- a/Sources/Semantic Analysis/Mangler.swift
+++ b/Sources/Semantic Analysis/Mangler.swift
@@ -52,12 +52,12 @@ enum Mangler {
     case let d as PropertyGetterDecl:
       s += "g" + mangle(d.parentType, root: false)
       s += d.propertyName.name.withCount
-      s += mangle(d.returnType.type!, root: false)
+      s += mangle(d.returnType.type, root: false)
       return s
     case let d as PropertySetterDecl:
       s += "s" + mangle(d.parentType, root: false)
       s += d.propertyName.name.withCount
-      s += mangle(d.args[1].type!, root: false)
+      s += mangle(d.args[1].type, root: false)
       return s
     case let d as MethodDecl:
       let sigil = d.has(attribute: .static) ? "m" : "M"
@@ -103,9 +103,9 @@ enum Mangler {
         }
       }
       s += arg.name.name.withCount
-      s += mangle(arg.type!, root: false)
+      s += mangle(arg.type, root: false)
     }
-    let returnType = d.returnType.type ?? .void
+    let returnType = d.returnType.type 
     if returnType != .void && !(d is InitializerDecl) {
       s += "R" + mangle(returnType, root: false)
     }
@@ -119,10 +119,13 @@ enum Mangler {
   static func mangle(_ t: DataType, root: Bool = true) -> String {
     var s = root ? "_WT" : ""
     switch t {
-    case .function(let args, let ret):
+    case .function(let args, let ret, let hasVarArgs):
       s += "F"
       for arg in args {
         s += mangle(arg, root: false)
+      }
+      if hasVarArgs {
+        s += "V"
       }
       s += "R" + mangle(ret, root: false)
     case .tuple(let fields):

--- a/Sources/Semantic Analysis/Mangler.swift
+++ b/Sources/Semantic Analysis/Mangler.swift
@@ -57,7 +57,7 @@ enum Mangler {
     case let d as PropertySetterDecl:
       s += "s" + mangle(d.parentType, root: false)
       s += d.propertyName.name.withCount
-      s += mangle(d.args[1].type, root: false)
+      s += mangle(d.args[1].type!, root: false)
       return s
     case let d as MethodDecl:
       let sigil = d.has(attribute: .static) ? "m" : "M"
@@ -103,7 +103,7 @@ enum Mangler {
         }
       }
       s += arg.name.name.withCount
-      s += mangle(arg.type, root: false)
+      s += mangle(arg.type!, root: false)
     }
     let returnType = d.returnType.type ?? .void
     if returnType != .void && !(d is InitializerDecl) {

--- a/Sources/Semantic Analysis/Sema.swift
+++ b/Sources/Semantic Analysis/Sema.swift
@@ -23,8 +23,8 @@ class Sema: ASTTransformer, Pass {
   
   func registerTopLevelDecls(in context: ASTContext) {
     for expr in context.extensions {
-      guard let typeDecl = context.decl(for: expr.type!) else {
-        error(SemaError.unknownType(type: expr.type!),
+      guard let typeDecl = context.decl(for: expr.type) else {
+        error(SemaError.unknownType(type: expr.type),
               loc: expr.startLoc,
               highlights: [ expr.sourceRange ])
         continue
@@ -44,7 +44,7 @@ class Sema: ASTTransformer, Pass {
         property.kind = .property(expr)
         if propertyNames.contains(property.name.name) {
           error(SemaError.duplicateField(name: property.name,
-                                         type: expr.type!),
+                                         type: expr.type),
                 loc: property.startLoc,
                 highlights: [ expr.name.range ])
           continue
@@ -56,7 +56,7 @@ class Sema: ASTTransformer, Pass {
         let mangled = Mangler.mangle(method)
         if methodNames.contains(mangled) {
           error(SemaError.duplicateMethod(name: method.name,
-                                          type: expr.type!),
+                                          type: expr.type),
                 loc: method.startLoc,
                 highlights: [ expr.name.range ])
           continue
@@ -103,7 +103,7 @@ class Sema: ASTTransformer, Pass {
         return
       }
     }
-    let returnType = decl.returnType.type!
+    let returnType = decl.returnType.type
     if !context.isValidType(returnType) {
       error(SemaError.unknownType(type: returnType),
             loc: decl.returnType.startLoc,
@@ -117,7 +117,7 @@ class Sema: ASTTransformer, Pass {
         returnType != .void,
         !decl.has(attribute: .implicit),
         !(decl is InitializerDecl) {
-      error(SemaError.notAllPathsReturn(type: decl.returnType.type!),
+      error(SemaError.notAllPathsReturn(type: decl.returnType.type),
             loc: decl.sourceRange?.start,
             highlights: [
               decl.name.range,
@@ -147,7 +147,7 @@ class Sema: ASTTransformer, Pass {
       return
     }
     guard !decl.has(attribute: .foreign) else { return }
-    if let rhs = decl.rhs { context.propagateContextualType(decl.type!, to: rhs) }
+    if let rhs = decl.rhs { context.propagateContextualType(decl.type, to: rhs) }
     if let type = decl.typeRef?.type {
       if !context.isValidType(type) {
         error(SemaError.unknownType(type: type),
@@ -173,7 +173,8 @@ class Sema: ASTTransformer, Pass {
     }
     
     if let rhs = decl.rhs, decl.typeRef == nil {
-      guard let type = rhs.type else { return }
+      let type = rhs.type
+      guard rhs.type != .error else { return }
       let canRhs = context.canonicalType(type)
       if case .void = canRhs {
         error(SemaError.incompleteTypeAccess(type: type, operation: "assign value from"),
@@ -215,8 +216,8 @@ class Sema: ASTTransformer, Pass {
   
   override func visitParamDecl(_ decl: ParamDecl) -> Result {
     super.visitParamDecl(decl)
-    guard context.isValidType(decl.type!) else {
-      error(SemaError.unknownType(type: decl.type!),
+    guard context.isValidType(decl.type) else {
+      error(SemaError.unknownType(type: decl.type),
             loc: decl.typeRef?.startLoc,
             highlights: [
               decl.typeRef?.sourceRange
@@ -224,7 +225,7 @@ class Sema: ASTTransformer, Pass {
       return
     }
     decl.kind = .local(currentFunction!)
-    let canTy = context.canonicalType(decl.type!)
+    let canTy = context.canonicalType(decl.type)
     if
       case .custom = canTy,
       let typeDecl = context.decl(for: canTy),
@@ -253,7 +254,8 @@ class Sema: ASTTransformer, Pass {
   ///            instead of a method
   func visitPropertyRefExpr(_ expr: PropertyRefExpr, callArgs: [Argument]?) -> FieldKind {
     super.visitPropertyRefExpr(expr)
-    guard let type = expr.lhs.type else {
+    let type = expr.lhs.type
+    guard type != .error else {
       // An error will already have been thrown from here
       return .property
     }
@@ -299,7 +301,7 @@ class Sema: ASTTransformer, Pass {
     if let callArgs = callArgs,
        let index = typeDecl.indexOfProperty(named: expr.name) {
       let property = typeDecl.properties[index]
-      if case .function(let args, _) = property.type! {
+      if case .function(let args, _, _) = property.type {
         let types = callArgs.flatMap { $0.val.type }
         if types.count == callArgs.count && args == types {
           expr.decl = property
@@ -317,7 +319,9 @@ class Sema: ASTTransformer, Pass {
          let funcDecl = context.candidate(forArgs: args, candidates: candidateMethods) {
         expr.decl = funcDecl
         let types = funcDecl.args.map { $0.type }
-        expr.type = .function(args: types as! [DataType], returnType: funcDecl.returnType.type!)
+        expr.type = .function(args: types,
+                              returnType: funcDecl.returnType.type,
+                              hasVarArgs: funcDecl.hasVarArgs)
         return .method
       } else {
         error(SemaError.ambiguousReference(name: expr.name),
@@ -346,7 +350,8 @@ class Sema: ASTTransformer, Pass {
       return
     }
     for value in expr.values {
-      guard let type = value.type else { return }
+      let type = value.type
+      guard type != .error else { return }
       guard matches(type, first) else {
         error(SemaError.nonMatchingArrayType(first, type),
               loc: value.startLoc,
@@ -363,16 +368,14 @@ class Sema: ASTTransformer, Pass {
     super.visitTupleExpr(expr)
     var types = [DataType]()
     for expr in expr.values {
-      guard let t = expr.type else { return }
-      types.append(t)
+      types.append(expr.type)
     }
     expr.type = .tuple(fields: types)
   }
   
   override func visitTupleFieldLookupExpr(_ expr: TupleFieldLookupExpr) -> Result {
     super.visitTupleFieldLookupExpr(expr)
-    guard let lhsTy = expr.lhs.type else { return }
-    let lhsCanTy = context.canonicalType(lhsTy)
+    let lhsCanTy = context.canonicalType(expr.lhs.type)
     guard case .tuple(let fields) = lhsCanTy else {
       error(SemaError.indexIntoNonTuple,
             loc: expr.startLoc,
@@ -394,7 +397,8 @@ class Sema: ASTTransformer, Pass {
   
   override func visitSubscriptExpr(_ expr: SubscriptExpr) -> Result {
     super.visitSubscriptExpr(expr)
-    guard let type = expr.lhs.type else { return }
+    let type = expr.lhs.type
+    guard type != .error else { return }
     let diagnose: () -> Void = {
       self.error(SemaError.cannotSubscript(type: type),
                  loc: expr.startLoc,
@@ -415,7 +419,7 @@ class Sema: ASTTransformer, Pass {
         diagnose()
         return
       }
-      elementType = candidate.returnType.type!
+      elementType = candidate.returnType.type
       expr.decl = candidate
     }
     guard elementType != .void else {
@@ -430,8 +434,8 @@ class Sema: ASTTransformer, Pass {
   }
   
   override func visitExtensionDecl(_ expr: ExtensionDecl) -> Result {
-    guard let decl = context.decl(for: expr.type!) else {
-      error(SemaError.unknownType(type: expr.type!),
+    guard let decl = context.decl(for: expr.type) else {
+      error(SemaError.unknownType(type: expr.type),
             loc: expr.startLoc,
             highlights: [ expr.typeRef.name.range ])
       return
@@ -450,7 +454,7 @@ class Sema: ASTTransformer, Pass {
       expr.name == "self" {
       expr.decl = VarAssignDecl(name: "self", typeRef: fn.returnType, kind: .implicitSelf(fn, currentType!))
       expr.isSelf = true
-      expr.type = fn.returnType.type!
+      expr.type = fn.returnType.type
       return
     }
     let candidates = context.functions(named: expr.name)
@@ -563,7 +567,7 @@ class Sema: ASTTransformer, Pass {
         }
       }
       if !missing.isEmpty {
-        error(SemaError.typeDoesNotConform(decl.type!, protocol: proto.type!),
+        error(SemaError.typeDoesNotConform(decl.type, protocol: proto.type),
               loc: decl.startLoc,
               highlights: [
                 conformance.name.range
@@ -577,7 +581,8 @@ class Sema: ASTTransformer, Pass {
   }
   
   override func visitTypeAliasDecl(_ decl: TypeAliasDecl) -> Result {
-    guard let bound = decl.bound.type else { return }
+    let bound = decl.bound.type
+    guard bound != .error else { return }
     guard context.isValidType(bound) else {
       error(SemaError.unknownType(type: bound),
             loc: decl.bound.startLoc,
@@ -594,7 +599,7 @@ class Sema: ASTTransformer, Pass {
     }
     
     for arg in expr.args {
-      guard arg.val.type != nil else { return }
+      guard arg.val.type != .error else { return }
     }
     var candidates = [FuncDecl]()
     var name: Identifier? = nil
@@ -610,10 +615,10 @@ class Sema: ASTTransformer, Pass {
       }
       switch propertyKind {
       case .property:
-        if case .function(var args, let ret)? = lhs.type {
-          candidates.append(context.implicitDecl(args: args, ret: ret))
-          args.insert(typeDecl.type!, at: 0)
-          lhs.type = .function(args: args, returnType: ret)
+        if case .function(var args, let ret, let hasVarArgs) = lhs.type {
+          candidates.append(context.implicitDecl(args: args, ret: ret, hasVarArgs: hasVarArgs))
+          args.insert(typeDecl.type, at: 0)
+          lhs.type = .function(args: args, returnType: ret, hasVarArgs: hasVarArgs)
         }
       case .staticMethod:
         candidates += typeDecl.staticMethods(named: lhs.name.name) as [FuncDecl]
@@ -629,9 +634,10 @@ class Sema: ASTTransformer, Pass {
       } else if let varDecl = varBindings[lhs.name.name] {
         setLHSDecl = { _ in } // override the decl if this is a function variable
         lhs.decl = varDecl
-        let type = context.canonicalType(varDecl.type!)
-        if case .function(let args, let ret) = type {
-          candidates.append(context.implicitDecl(args: args, ret: ret))
+        let type = context.canonicalType(varDecl.type)
+        if case .function(let args, let ret, let hasVarArgs) = type {
+          candidates.append(context.implicitDecl(args: args, ret: ret,
+                                                 hasVarArgs: hasVarArgs))
         } else {
           error(SemaError.callNonFunction(type: type),
                 loc: lhs.startLoc,
@@ -645,10 +651,11 @@ class Sema: ASTTransformer, Pass {
       }
     default:
       visit(expr.lhs)
-      if case .function(let args, let ret)? = expr.lhs.type {
-        candidates += [context.implicitDecl(args: args, ret: ret)]
+      if case .function(let args, let ret, let hasVarArgs) = expr.lhs.type {
+        candidates += [context.implicitDecl(args: args, ret: ret,
+                                            hasVarArgs: hasVarArgs)]
       } else {
-        error(SemaError.callNonFunction(type: expr.lhs.type ?? .void),
+        error(SemaError.callNonFunction(type: expr.lhs.type ),
               loc: expr.lhs.startLoc,
               highlights: [
                 expr.lhs.sourceRange
@@ -736,14 +743,16 @@ class Sema: ASTTransformer, Pass {
     super.visitClosureExpr(expr)
     var argTys = [DataType]()
     for arg in expr.args {
-      argTys.append(arg.type!)
+      argTys.append(arg.type)
     }
-    expr.type = .function(args: argTys, returnType: expr.returnType!.type!)
+    expr.type = .function(args: argTys, returnType: expr.returnType!.type,
+                          hasVarArgs: false)
   }
   
   override func visitSwitchStmt(_ stmt: SwitchStmt) {
     super.visitSwitchStmt(stmt)
-    guard let valueType = stmt.value.type else { return }
+    let valueType = stmt.value.type
+    guard valueType != .error else { return }
     for c in stmt.cases {
       guard context.isGlobalConstant(c.constant) else {
         error(SemaError.caseMustBeConstant,
@@ -754,7 +763,7 @@ class Sema: ASTTransformer, Pass {
       guard let decl = context.infixOperatorCandidate(.equalTo,
                                                       lhs: stmt.value,
                                                       rhs: c.constant),
-               !decl.returnType.type!.isPointer else {
+               !decl.returnType.type.isPointer else {
         error(SemaError.cannotSwitch(type: valueType),
               loc: stmt.value.startLoc,
               highlights: [ stmt.value.sourceRange ])
@@ -786,8 +795,9 @@ class Sema: ASTTransformer, Pass {
   
   override func visitInfixOperatorExpr(_ expr: InfixOperatorExpr) {
     super.visitInfixOperatorExpr(expr)
-    guard var lhsType = expr.lhs.type else { return }
-    guard var rhsType = expr.rhs.type else { return }
+    var lhsType = expr.lhs.type
+    var rhsType = expr.rhs.type
+    guard lhsType != .error, rhsType != .error else { return }
     
     if context.propagateContextualType(rhsType, to: expr.lhs) {
       lhsType = rhsType
@@ -818,7 +828,8 @@ class Sema: ASTTransformer, Pass {
           return
         }
       }
-      if expr.rhs is NilExpr, let lhsType = expr.lhs.type {
+      let lhsType = expr.lhs.type
+      if expr.rhs is NilExpr, lhsType != .error {
         guard context.canBeNil(lhsType) else {
           error(SemaError.nonPointerNil(type: lhsType),
                 loc: expr.lhs.startLoc,
@@ -834,8 +845,8 @@ class Sema: ASTTransformer, Pass {
       }
     }
     if case .as = expr.op {
-      guard context.isValidType(expr.rhs.type!) else {
-        error(SemaError.unknownType(type: expr.rhs.type!),
+      guard context.isValidType(expr.rhs.type) else {
+        error(SemaError.unknownType(type: expr.rhs.type),
               loc: expr.rhs.startLoc,
               highlights: [expr.rhs.sourceRange])
         return
@@ -854,13 +865,13 @@ class Sema: ASTTransformer, Pass {
       return
     }
     if case .is = expr.op {
-      guard context.isValidType(expr.rhs.type!) else {
-        error(SemaError.unknownType(type: expr.rhs.type!),
+      guard context.isValidType(expr.rhs.type) else {
+        error(SemaError.unknownType(type: expr.rhs.type),
               loc: expr.rhs.startLoc,
               highlights: [expr.rhs.sourceRange])
         return
       }
-      guard case .any? = expr.lhs.type else {
+      guard case .any = expr.lhs.type else {
         let matched = !matches(expr.lhs.type, expr.rhs.type)
         error(SemaError.isCheckAlways(fails: matched),
               loc: expr.opRange?.start,
@@ -935,7 +946,8 @@ class Sema: ASTTransformer, Pass {
   
   override func visitPrefixOperatorExpr(_ expr: PrefixOperatorExpr) {
     super.visitPrefixOperatorExpr(expr)
-    guard let rhsType = expr.rhs.type else { return }
+    let rhsType = expr.rhs.type
+    guard rhsType != .error else { return }
     guard let exprType = expr.type(forArgType: context.canonicalType(rhsType)) else {
       error(SemaError.invalidOperands(op: expr.op, invalid: rhsType),
             loc: expr.opRange?.start,

--- a/Sources/Semantic Analysis/SemaError.swift
+++ b/Sources/Semantic Analysis/SemaError.swift
@@ -64,7 +64,7 @@ enum SemaError: Error, CustomStringConvertible {
     case .unknownVariableName(let name):
       return "unknown variable '\(name)'"
     case .unknownProperty(let typeDecl, let expr):
-      return "unknown property '\(expr.name)' in type '\(typeDecl.type!)'"
+      return "unknown property '\(expr.name)' in type '\(typeDecl.type)'"
     case .invalidOperands(let op, let invalid):
       return "invalid argument for operator '\(op)' (got '\(invalid)')"
     case .cannotSubscript(let type):
@@ -100,13 +100,9 @@ enum SemaError: Error, CustomStringConvertible {
         if let label = $0.label {
           d += "\(label): "
         }
-        if let t = $0.val.type {
-          d += "\(t)"
-        } else {
-          d += "<<error type>>"
-        }
+        d += "\($0.val.type)"
         return d
-        }.joined(separator: ", ")
+      }.joined(separator: ", ")
       s += ")"
       return s
     case .candidates(let functions):

--- a/Sources/Semantic Analysis/SemaError.swift
+++ b/Sources/Semantic Analysis/SemaError.swift
@@ -64,7 +64,7 @@ enum SemaError: Error, CustomStringConvertible {
     case .unknownVariableName(let name):
       return "unknown variable '\(name)'"
     case .unknownProperty(let typeDecl, let expr):
-      return "unknown property '\(expr.name)' in type '\(typeDecl.type)'"
+      return "unknown property '\(expr.name)' in type '\(typeDecl.type!)'"
     case .invalidOperands(let op, let invalid):
       return "invalid argument for operator '\(op)' (got '\(invalid)')"
     case .cannotSubscript(let type):

--- a/Sources/Semantic Analysis/Solver.swift
+++ b/Sources/Semantic Analysis/Solver.swift
@@ -8,14 +8,24 @@
 
 final class Solver {
   typealias ConstraintSystem = [Constraint]
-  typealias Solution = [String:DataType]
+  typealias Solution = [String: DataType]
 
-  enum Constraint {
-    case Eq(DataType, DataType)
+  enum ConstraintKind {
+    case equal(DataType, DataType)
   }
 
-  static func solveSystem(_ cs : ConstraintSystem) -> Solution {
-    var sub : Solution = [:]
+  struct Constraint {
+    let kind: ConstraintKind
+    let location: StaticString
+    let node: ASTNode?
+
+    func withKind(_ kind: ConstraintKind) -> Constraint {
+      return Constraint(kind: kind, location: location, node: node)
+    }
+  }
+
+  static func solveSystem(_ cs: ConstraintSystem) -> Solution {
+    var sub: Solution = [:]
     for c in cs {
       let soln = self.solveSingle(c)
 
@@ -25,9 +35,9 @@ final class Solver {
   }
 
   // Unify
-  static func solveSingle(_ c : Constraint) -> Solution {
-    switch c {
-    case let .Eq(t1, t2):
+  static func solveSingle(_ c: Constraint) -> Solution {
+    switch c.kind {
+    case let .equal(t1, t2):
       // If the two types are already equal there's nothing to be done.
       if t1 == t2 {
         return [:]
@@ -40,16 +50,24 @@ final class Solver {
           fatalError("Infinite type")
         }
         // Unify the metavariable with the concrete type.
-        return [m:t]
+        return [m: t]
       case let (.typeVariable(m), t), let (t, .typeVariable(m)):
         // Perform the occurs check
         if t.contains(m) {
           fatalError("Infinite type")
         }
         // Unify the type variable with the concrete type.
-        return [m:t]
-      case let (.function(args1, returnType1), .function(args2, returnType2)):
-        return solveSystem([.Eq(returnType1, returnType2)] + zip(args1, args2).map(Constraint.Eq))
+        return [m: t]
+      case let (.function(args1, returnType1, hasVarArgs1), .function(args2, returnType2, hasVarArgs2)):
+
+        guard args1.count == args2.count || hasVarArgs1 || hasVarArgs2 else {
+          break
+        }
+
+        var system = zip(args1, args2).map(ConstraintKind.equal)
+        system.insert(.equal(returnType1, returnType2), at: 0)
+
+        return solveSystem(system.map(c.withKind))
       case (.pointer(_), .pointer(_)):
         // Pointers may unify with any other kind of pointer.
         return [:]
@@ -60,23 +78,25 @@ final class Solver {
         // Anything can unify to an existential
         return [:]
       default:
-        fatalError()
+        break
       }
+      let rangeText = c.node?.sourceRange.map { " \($0.start)" } ?? ""
+      fatalError("[\(c.location)]:\(rangeText) could not unify \(t1) with \(t2)")
     }
   }
 
   final class Generator: ASTTransformer {
     var goal: DataType? = nil
-    var env: [Identifier:DataType] = [:]
+    var env: [Identifier: DataType] = [:]
     var constraints: [Constraint] = []
 
-    func reset(with env: [Identifier:DataType]) {
+    func reset(with env: [Identifier: DataType]) {
       self.goal = nil
       self.env = env
       self.constraints = []
     }
 
-    func byBinding(_ n : Identifier, _ t : DataType, _ f : () -> ()) {
+    func byBinding(_ n: Identifier, _ t: DataType, _ f: () -> ()) {
       let oldEnv = self.env
       self.env[n] = t
       f()
@@ -96,37 +116,45 @@ final class Solver {
         return
       }
       
-      let functions = self.context.functions(named: expr.name)
-      guard !functions.isEmpty else {
-        fatalError()
-      }
-
-      // If we can avoid overload resolution, avoid it
-      if functions.count == 1 {
-        self.goal = functions[0].type!
-      } else {
-        self.goal = DataType.function(args: [ DataType.freshTypeVariable ], returnType: DataType.freshTypeVariable)
-      }
+//      let functions = self.context.functions(named: expr.name)
+//      guard !functions.isEmpty else {
+//        fatalError()
+//      }
+//
+//      // If we can avoid overload resolution, avoid it
+//      if functions.count == 1 {
+//        self.goal = functions[0].type!
+//      } else {
+//        self.goal = DataType.function(args: [ DataType.freshTypeVariable ], returnType: DataType.freshTypeVariable, hasVarArgs: false)
+//      }
+      self.goal = expr.decl!.type
     }
 
     override func visitSizeofExpr(_ expr: SizeofExpr) {
-      self.goal = expr.type!
+      self.goal = expr.type
     }
 
     override func visitPropertyRefExpr(_ expr: PropertyRefExpr) {
-      self.goal = expr.type!
+      visit(expr.lhs)
+      let lhsGoal = self.goal!
+      constrainEqual(expr.typeDecl!, lhsGoal)
+
+      let tau = DataType.freshMetaVariable
+      constrainEqual(expr.decl!, tau)
+
+      self.goal = tau
     }
 
     override func visitVarAssignDecl(_ expr: VarAssignDecl) {
       let goalType: DataType
-      // let <ident> : <Type> = <expr>
-      if let e = expr.rhs, let t = expr.type {
-        goalType = t
+      // let <ident>: <Type> = <expr>
+      if let e = expr.rhs {
+        goalType = e.type
         byBinding(expr.name, goalType, {
           visit(e)
         })
         // Bind the given type to the goal type the initializer generated.
-        self.constraints.append(.Eq(goalType, self.goal!))
+        constrainEqual(goalType, self.goal!, node: e)
       }
       // let <ident> = <expr>
       else if let e = expr.rhs {
@@ -137,15 +165,11 @@ final class Solver {
         })
         let phi = Solver.solveSystem(self.constraints)
         goalType = tau.substitute(phi)
-      }
-      // let <ident> : <Type>
-      else if let t = expr.type {
+      } else {
+        // let <ident>: <Type>
         // Take the type binding as fact and move on.
-        goalType = t
+        goalType = expr.type
         self.env[expr.name] = goalType
-      }
-      else {
-        fatalError()
       }
 
       self.goal = goalType
@@ -156,79 +180,192 @@ final class Solver {
         let oldEnv = self.env
         for p in expr.args {
           // Bind the type of the parameters.
-          self.env[p.name] = p.type!
+          self.env[p.name] = p.type
         }
         // Walk into the function body
         self.visit(body)
         self.env = oldEnv
       }
-      self.goal = expr.type!
+      self.goal = expr.type
     }
 
     override func visitFuncCallExpr(_ expr: FuncCallExpr) {
       visit(expr.lhs)
       let lhsGoal = self.goal!
-      var goals : [DataType] = []
+      var goals = [DataType]()
       if let pre = expr.lhs as? PropertyRefExpr {
-        goals.append(pre.lhs.type!)
+        goals.append(pre.lhs.type)
       }
-      expr.args.forEach { a in
-        visit(a.val)
+      for arg in expr.args {
+        visit(arg.val)
         goals.append(self.goal!)
       }
       let tau = DataType.freshMetaVariable
-      self.constraints.append(.Eq(lhsGoal, .function(args: goals, returnType: tau)))
+      constrainEqual(lhsGoal,
+                     .function(args: goals, returnType: tau, hasVarArgs: false),
+                     node: expr.lhs)
       self.goal = tau
     }
 
     override func visitInfixOperatorExpr(_ expr: InfixOperatorExpr) {
-      let lhsGoal = expr.decl!.type!
-      var goals : [DataType] = []
+      let tau = DataType.freshMetaVariable
+      if case .as = expr.op {
+        constrainEqual(expr, tau)
+        constrainEqual(expr.rhs, tau)
+        self.goal = tau
+        return
+      }
+      if case .is = expr.op {
+        constrainEqual(expr, .bool)
+        constrainEqual(expr.rhs, tau)
+        self.goal = tau
+        return
+      }
+      let lhsGoal = expr.decl!.type
+      var goals: [DataType] = []
       [ expr.lhs, expr.rhs ].forEach { e in
         visit(e)
         goals.append(self.goal!)
       }
-      let tau = DataType.freshMetaVariable
-      self.constraints.append(.Eq(lhsGoal, .function(args: goals, returnType: tau)))
+      constrainEqual(lhsGoal,
+                     .function(args: goals, returnType: tau, hasVarArgs: false),
+                     node: expr.lhs)
       self.goal = tau
     }
 
     override func visitSubscriptExpr(_ expr: SubscriptExpr) {
       visit(expr.lhs)
-      var goals : [DataType] = [ self.goal! ]
+      var goals: [DataType] = [ self.goal! ]
       expr.args.forEach { a in
         visit(a.val)
         goals.append(self.goal!)
       }
       let tau = DataType.freshMetaVariable
-      self.constraints.append(.Eq(expr.decl!.type!, .function(args: goals, returnType: tau)))
+      if let decl = expr.decl {
+        constrainEqual(decl, .function(args: goals, returnType: tau, hasVarArgs: false))
+      }
       self.goal = tau
+    }
+
+    override func visitArrayExpr(_ expr: ArrayExpr) {
+      guard case .array(_, let length) = expr.type else {
+        fatalError("invalid array type")
+      }
+      let tau = DataType.freshMetaVariable
+      for value in expr.values {
+        visit(value)
+        constrainGoal(tau, node: value)
+      }
+      let goal = DataType.array(field: tau, length: length)
+      constrainEqual(expr, goal)
+      self.goal = goal
+    }
+
+    override func visitTupleExpr(_ expr: TupleExpr) {
+      var goals = [DataType]()
+      for element in expr.values {
+        visit(element)
+        goals.append(self.goal!)
+      }
+      constrainEqual(expr, .tuple(fields: goals))
+      self.goal = expr.type
+    }
+
+    override func visitTernaryExpr(_ expr: TernaryExpr) {
+      let tau = DataType.freshMetaVariable
+
+      visit(expr.condition)
+      constrainEqual(expr.condition, .bool)
+
+      visit(expr.trueCase)
+      constrainEqual(expr.trueCase, tau)
+
+      visit(expr.falseCase)
+      constrainEqual(expr.falseCase, tau)
+
+      constrainEqual(expr, tau)
+      self.goal = tau
+    }
+
+    override func visitPrefixOperatorExpr(_ expr: PrefixOperatorExpr) {
+      visit(expr.rhs)
+      let rhsGoal = self.goal!
+      switch expr.op {
+      case .ampersand:
+        constrainEqual(expr, .pointer(type: rhsGoal))
+      case .bitwiseNot:
+        constrainEqual(expr, rhsGoal)
+      case .minus:
+        constrainEqual(expr, rhsGoal)
+      case .not:
+        constrainEqual(expr, .bool)
+        constrainEqual(rhsGoal, .bool, node: expr.rhs)
+      case .star:
+        guard case .pointer(let element) = expr.rhs.type else {
+          fatalError("invalid dereference?")
+        }
+        constrainEqual(expr, element)
+      default:
+        fatalError("invalid prefix operator: \(expr.op)")
+      }
+    }
+
+    override func visitTupleFieldLookupExpr(_ expr: TupleFieldLookupExpr) {
+      visit(expr.lhs)
+      let lhsGoal = self.goal!
+
+      constrainEqual(expr.decl!, lhsGoal)
+      let tau = DataType.freshMetaVariable
+
+      constrainEqual(expr, tau)
+      self.goal = tau
+    }
+
+    override func visitParenExpr(_ expr: ParenExpr) {
+      visit(expr.value)
+      self.goal = expr.type
+    }
+
+    func constrainEqual(_ d: Decl, _ t: DataType, caller: StaticString = #function) {
+      constraints.append(Constraint(kind: .equal(d.type, t), location: caller, node: d))
+    }
+
+    func constrainEqual(_ e: Expr, _ t: DataType, caller: StaticString = #function) {
+      constraints.append(Constraint(kind: .equal(e.type, t), location: caller, node: e))
+    }
+
+    func constrainEqual(_ t1: DataType, _ t2: DataType, node: ASTNode? = nil, caller: StaticString = #function) {
+      constraints.append(Constraint(kind: .equal(t1, t2), location: caller, node: node))
+    }
+
+    func constrainGoal(_ t: DataType, node: ASTNode? = nil, caller: StaticString = #function) {
+      constraints.append(Constraint(kind: .equal(goal!, t), location: caller, node: node))
     }
 
     // MARK: Literals
 
-    override func visitNumExpr(_ expr: NumExpr) { self.goal = expr.type! }
-    override func visitCharExpr(_ expr: CharExpr) { self.goal = expr.type! }
-    override func visitFloatExpr(_ expr: FloatExpr) { self.goal = expr.type! }
-    override func visitBoolExpr(_ expr: BoolExpr) { self.goal = expr.type! }
-    override func visitVoidExpr(_ expr: VoidExpr) { self.goal = expr.type! }
-    override func visitNilExpr(_ expr: NilExpr) { self.goal = expr.type! }
-    override func visitStringExpr(_ expr: StringExpr) { self.goal = expr.type! }
+    override func visitNumExpr(_ expr: NumExpr) { self.goal = expr.type }
+    override func visitCharExpr(_ expr: CharExpr) { self.goal = expr.type }
+    override func visitFloatExpr(_ expr: FloatExpr) { self.goal = expr.type }
+    override func visitBoolExpr(_ expr: BoolExpr) { self.goal = expr.type }
+    override func visitVoidExpr(_ expr: VoidExpr) { self.goal = expr.type }
+    override func visitNilExpr(_ expr: NilExpr) { self.goal = expr.type }
+    override func visitStringExpr(_ expr: StringExpr) { self.goal = expr.type }
   }
 }
 
 extension Dictionary {
-  mutating func unionInPlace(_ with : Dictionary) {
+  mutating func unionInPlace(_ with: Dictionary) {
     with.forEach { self.updateValue($1, forKey: $0) }
   }
 
-  func union(_ other : Dictionary) -> Dictionary {
+  func union(_ other: Dictionary) -> Dictionary {
     var dictionary = other
     dictionary.unionInPlace(self)
     return dictionary
   }
 
-  init<S : Sequence>(_ pairs : S) where S.Iterator.Element == (Key, Value) {
+  init<S: Sequence>(_ pairs: S) where S.Iterator.Element == (Key, Value) {
     self.init()
     var g = pairs.makeIterator()
     while let (k, v): (Key, Value) = g.next() {

--- a/Sources/Semantic Analysis/Solver.swift
+++ b/Sources/Semantic Analysis/Solver.swift
@@ -1,0 +1,224 @@
+//
+//  CSGen.swift
+//  Trill
+//
+//  Created by Robert Widmann on 3/14/17.
+//  Copyright © 2017 Harlan. All rights reserved.
+//
+
+final class Solver {
+  typealias ConstraintSystem = [Constraint]
+  typealias Solution = [String:DataType]
+
+  enum Constraint {
+    case Eq(DataType, DataType)
+  }
+
+  static func solveSystem(_ cs : ConstraintSystem) -> Solution {
+    var sub : Solution = [:]
+    for c in cs {
+      let soln = self.solveSingle(c)
+
+      sub.unionInPlace(soln)
+    }
+    return sub
+  }
+
+  // Unify
+  static func solveSingle(_ c : Constraint) -> Solution {
+    switch c {
+    case let .Eq(t1, t2):
+      // If the two types are already equal there's nothing to be done.
+      if t1 == t2 {
+        return [:]
+      }
+
+      switch (t1, t2) {
+      case let (.metaVariable(m), t), let (t, .metaVariable(m)):
+        // Perform the occurs check
+        if t.contains(m) {
+          fatalError("Infinite type")
+        }
+        // Unify the metavariable with the concrete type.
+        return [m:t]
+      case let (.typeVariable(m), t), let (t, .typeVariable(m)):
+        // Perform the occurs check
+        if t.contains(m) {
+          fatalError("Infinite type")
+        }
+        // Unify the type variable with the concrete type.
+        return [m:t]
+      case let (.function(args1, returnType1), .function(args2, returnType2)):
+        return solveSystem([.Eq(returnType1, returnType2)] + zip(args1, args2).map(Constraint.Eq))
+      case (.pointer(_), .pointer(_)):
+        // Pointers may unify with any other kind of pointer.
+        return [:]
+      case (.bool, .int):
+        // Boolean values may coerce to integer values (but not vice-versa).
+        return [:]
+      case (_, .any):
+        // Anything can unify to an existential
+        return [:]
+      default:
+        fatalError()
+      }
+    }
+  }
+
+  final class Generator: ASTTransformer {
+    var goal: DataType? = nil
+    var env: [Identifier:DataType] = [:]
+    var constraints: [Constraint] = []
+
+    func reset() {
+      self.goal = nil
+      self.env = [:]
+      self.constraints = []
+    }
+
+    func byBinding(_ n : Identifier, _ t : DataType, _ f : () -> ()) {
+      let oldEnv = self.env
+      self.env[n] = t
+      f()
+      self.env = oldEnv
+    }
+
+    // MARK: Monotypes
+
+    override func visitVarExpr(_ expr: VarExpr) {
+      if expr.isSelf {
+        self.goal = expr.type
+        return
+      }
+
+      if let t = self.env[expr.name] ?? self.context.global(named: expr.name)?.type {
+        self.goal = t
+        return
+      }
+      
+      let functions = self.context.functions(named: expr.name)
+      guard !functions.isEmpty else {
+        fatalError()
+      }
+
+      // If we can avoid overload resolution, avoid it
+      if functions.count == 1 {
+        self.goal = functions[0].type!
+      } else {
+        self.goal = DataType.function(args: [ DataType.freshTypeVariable ], returnType: DataType.freshTypeVariable)
+      }
+    }
+
+    override func visitSizeofExpr(_ expr: SizeofExpr) {
+      self.goal = expr.type!
+    }
+
+    override func visitPropertyRefExpr(_ expr: PropertyRefExpr) {
+      self.goal = expr.type!
+    }
+
+    override func visitVarAssignDecl(_ expr: VarAssignDecl) {
+      let goalType: DataType
+      // let <ident> : <Type> = <expr>
+      if let e = expr.rhs, let t = expr.type {
+        goalType = t
+        byBinding(expr.name, goalType, {
+          visit(e)
+        })
+        // Bind the given type to the goal type the initializer generated.
+        self.constraints.append(.Eq(goalType, self.goal!))
+      }
+      // let <ident> = <expr>
+      else if let e = expr.rhs {
+        // Generate 
+        let tau = DataType.freshMetaVariable
+        byBinding(expr.name, tau, {
+          visit(e)
+        })
+        let phi = Solver.solveSystem(self.constraints)
+        goalType = tau.substitute(phi)
+      }
+      // let <ident> : <Type>
+      else if let t = expr.type {
+        // Take the type binding as fact and move on.
+        goalType = t
+        self.env[expr.name] = goalType
+      }
+      else {
+        fatalError()
+      }
+
+      self.goal = goalType
+    }
+
+    override func visitFuncDecl(_ expr: FuncDecl) {
+      if let body = expr.body {
+        let oldEnv = self.env
+        for p in expr.args {
+          // Bind the type of the parameters.
+          self.env[p.name] = p.type!
+        }
+        // Walk into the function body
+        self.visit(body)
+        self.env = oldEnv
+      }
+      self.goal = expr.type!
+    }
+
+    override func visitFuncCallExpr(_ expr: FuncCallExpr) {
+      visit(expr.lhs)
+      let lhsGoal = self.goal!
+      var goals : [DataType] = []
+      expr.args.forEach {
+        visit($0.val)
+        goals.append(self.goal!)
+      }
+      let tau = DataType.freshMetaVariable
+      self.constraints.append(.Eq(lhsGoal, .function(args: goals, returnType: tau)))
+      self.goal = tau
+    }
+
+    override func visitInfixOperatorExpr(_ expr: InfixOperatorExpr) {
+      let lhsGoal = expr.type!
+      var goals : [DataType] = []
+      [ expr.lhs, expr.rhs ].forEach { e in
+        visit(e)
+        goals.append(self.goal!)
+      }
+      let tau = DataType.freshMetaVariable
+      self.constraints.append(.Eq(lhsGoal, .function(args: goals, returnType: tau)))
+      self.goal = tau
+    }
+
+    // MARK: Literals
+
+    override func visitNumExpr(_ expr: NumExpr) { self.goal = expr.type! }
+    override func visitCharExpr(_ expr: CharExpr) { self.goal = expr.type! }
+    override func visitFloatExpr(_ expr: FloatExpr) { self.goal = expr.type! }
+    override func visitBoolExpr(_ expr: BoolExpr) { self.goal = expr.type! }
+    override func visitVoidExpr(_ expr: VoidExpr) { self.goal = expr.type! }
+    override func visitNilExpr(_ expr: NilExpr) { self.goal = expr.type! }
+    override func visitStringExpr(_ expr: StringExpr) { self.goal = expr.type! }
+  }
+}
+
+extension Dictionary {
+  mutating func unionInPlace(_ with : Dictionary) {
+    with.forEach { self.updateValue($1, forKey: $0) }
+  }
+
+  func union(_ other : Dictionary) -> Dictionary {
+    var dictionary = other
+    dictionary.unionInPlace(self)
+    return dictionary
+  }
+
+  init<S : Sequence>(_ pairs : S) where S.Iterator.Element == (Key, Value) {
+    self.init()
+    var g = pairs.makeIterator()
+    while let (k, v): (Key, Value) = g.next() {
+      self[k] = v
+    }
+  }
+}
+

--- a/Sources/Semantic Analysis/Solver.swift
+++ b/Sources/Semantic Analysis/Solver.swift
@@ -79,14 +79,17 @@ final class Solver {
       case (.bool, .int):
         // Boolean values may coerce to integer values (but not vice-versa).
         return [:]
-      case (_, .any):
+      case (_, .any), (.any, _):
         // Anything can unify to an existential
         return [:]
       default:
         break
       }
-      let rangeText = c.node?.sourceRange.map { " \($0.start)" } ?? ""
-      context.diag.error("[\(c.location)]:\(rangeText) could not unify \(t1) with \(t2)")
+      context.diag.error("cannot convert value of type \(t1) to \(t2)",
+                         loc: c.node?.startLoc,
+                         highlights: [
+                           c.node?.sourceRange
+                         ])
       return [:]
     }
   }

--- a/Sources/Semantic Analysis/Solver.swift
+++ b/Sources/Semantic Analysis/Solver.swift
@@ -42,27 +42,46 @@ final class Solver {
   // Unify
   func solveSingle(_ c: Constraint) -> Solution? {
     switch c.kind {
-    case let .equal(t1, t2):
+    case let .equal(_t1, _t2):
+
+      // Canonicalize types before checking.
+      let t1 = context.canonicalType(_t1)
+      let t2 = context.canonicalType(_t2)
+
       // If the two types are already equal there's nothing to be done.
       if t1 == t2 {
         return [:]
       }
 
       switch (t1, t2) {
-      case let (.metaVariable(m), t), let (t, .metaVariable(m)):
+      case let (t, .metaVariable(m)):
         // Perform the occurs check
         if t.contains(m) {
           fatalError("Infinite type")
         }
         // Unify the metavariable with the concrete type.
-        return [m: t]
-      case let (.typeVariable(m), t), let (t, .typeVariable(m)):
+        return [m: _t1]
+      case let (.metaVariable(m), t):
+        // Perform the occurs check
+        if t.contains(m) {
+          fatalError("Infinite type")
+        }
+        // Unify the metavariable with the concrete type.
+        return [m: _t2]
+      case let (t, .typeVariable(m)):
         // Perform the occurs check
         if t.contains(m) {
           fatalError("Infinite type")
         }
         // Unify the type variable with the concrete type.
-        return [m: t]
+        return [m: _t1]
+      case let (.typeVariable(m), t):
+        // Perform the occurs check
+        if t.contains(m) {
+          fatalError("Infinite type")
+        }
+        // Unify the type variable with the concrete type.
+        return [m: _t2]
       case let (.function(args1, returnType1, hasVarArgs1), .function(args2, returnType2, hasVarArgs2)):
 
         guard args1.count == args2.count || hasVarArgs1 || hasVarArgs2 else {
@@ -95,12 +114,12 @@ final class Solver {
   }
 
   final class Generator: ASTTransformer {
-    var goal: DataType? = nil
+    var goal: DataType = .error
     var env: [Identifier: DataType] = [:]
     var constraints: [Constraint] = []
 
     func reset(with env: [Identifier: DataType]) {
-      self.goal = nil
+      self.goal = .error
       self.env = env
       self.constraints = []
     }
@@ -145,7 +164,7 @@ final class Solver {
 
     override func visitPropertyRefExpr(_ expr: PropertyRefExpr) {
       visit(expr.lhs)
-      let lhsGoal = self.goal!
+      let lhsGoal = self.goal
       constrainEqual(expr.typeDecl!, lhsGoal)
 
       let tau = DataType.freshMetaVariable
@@ -163,7 +182,7 @@ final class Solver {
           visit(e)
         })
         // Bind the given type to the goal type the initializer generated.
-        constrainEqual(goalType, self.goal!, node: e)
+        constrainEqual(goalType, self.goal, node: e)
       }
       // let <ident> = <expr>
       else if let e = expr.rhs {
@@ -203,14 +222,14 @@ final class Solver {
 
     override func visitFuncCallExpr(_ expr: FuncCallExpr) {
       visit(expr.lhs)
-      let lhsGoal = self.goal!
+      let lhsGoal = self.goal
       var goals = [DataType]()
       if let pre = expr.lhs as? PropertyRefExpr {
         goals.append(pre.lhs.type)
       }
       for arg in expr.args {
         visit(arg.val)
-        goals.append(self.goal!)
+        goals.append(self.goal)
       }
       let tau = DataType.freshMetaVariable
       constrainEqual(lhsGoal,
@@ -237,7 +256,7 @@ final class Solver {
       var goals: [DataType] = []
       [ expr.lhs, expr.rhs ].forEach { e in
         visit(e)
-        goals.append(self.goal!)
+        goals.append(self.goal)
       }
       constrainEqual(lhsGoal,
                      .function(args: goals, returnType: tau, hasVarArgs: false),
@@ -247,10 +266,10 @@ final class Solver {
 
     override func visitSubscriptExpr(_ expr: SubscriptExpr) {
       visit(expr.lhs)
-      var goals: [DataType] = [ self.goal! ]
+      var goals: [DataType] = [ self.goal ]
       expr.args.forEach { a in
         visit(a.val)
-        goals.append(self.goal!)
+        goals.append(self.goal)
       }
       let tau = DataType.freshMetaVariable
       if let decl = expr.decl {
@@ -277,7 +296,7 @@ final class Solver {
       var goals = [DataType]()
       for element in expr.values {
         visit(element)
-        goals.append(self.goal!)
+        goals.append(self.goal)
       }
       constrainEqual(expr, .tuple(fields: goals))
       self.goal = expr.type
@@ -301,7 +320,7 @@ final class Solver {
 
     override func visitPrefixOperatorExpr(_ expr: PrefixOperatorExpr) {
       visit(expr.rhs)
-      let rhsGoal = self.goal!
+      let rhsGoal = self.goal
       switch expr.op {
       case .ampersand:
         constrainEqual(expr, .pointer(type: rhsGoal))
@@ -324,7 +343,7 @@ final class Solver {
 
     override func visitTupleFieldLookupExpr(_ expr: TupleFieldLookupExpr) {
       visit(expr.lhs)
-      let lhsGoal = self.goal!
+      let lhsGoal = self.goal
 
       constrainEqual(expr.decl!, lhsGoal)
       let tau = DataType.freshMetaVariable
@@ -336,6 +355,18 @@ final class Solver {
     override func visitParenExpr(_ expr: ParenExpr) {
       visit(expr.value)
       self.goal = expr.type
+    }
+
+    override func visitTypeRefExpr(_ expr: TypeRefExpr) {
+      self.goal = expr.type
+    }
+
+    override func visitPoundFunctionExpr(_ expr: PoundFunctionExpr) {
+      visitStringExpr(expr)
+    }
+
+    override func visitClosureExpr(_ expr: ClosureExpr) {
+      // TODO: Implement this
     }
 
     func constrainEqual(_ d: Decl, _ t: DataType, caller: StaticString = #function) {
@@ -351,7 +382,7 @@ final class Solver {
     }
 
     func constrainGoal(_ t: DataType, node: ASTNode? = nil, caller: StaticString = #function) {
-      constraints.append(Constraint(kind: .equal(goal!, t), location: caller, node: node))
+      constraints.append(Constraint(kind: .equal(goal, t), location: caller, node: node))
     }
 
     // MARK: Literals

--- a/Sources/Semantic Analysis/TypeChecker.swift
+++ b/Sources/Semantic Analysis/TypeChecker.swift
@@ -200,7 +200,7 @@ class TypeChecker: ASTTransformer, Pass {
     self.csGen.reset(with: self.env)
     self.csGen.visit(expr)
     if let soln = Solver(context: context).solveSystem(csGen.constraints) {
-      expr.type = csGen.goal!.substitute(soln)
+      expr.type = csGen.goal.substitute(soln)
     }
   }
   
@@ -208,7 +208,7 @@ class TypeChecker: ASTTransformer, Pass {
     self.csGen.reset(with: self.env)
     self.csGen.visit(decl)
     if let soln = Solver(context: context).solveSystem(csGen.constraints) {
-      decl.type = csGen.goal!.substitute(soln)
+      decl.type = csGen.goal.substitute(soln)
     }
     self.env[decl.name] = decl.type
   }
@@ -301,7 +301,7 @@ class TypeChecker: ASTTransformer, Pass {
     self.csGen.reset(with: self.env)
     self.csGen.visit(expr)
     if let soln = Solver(context: context).solveSystem(csGen.constraints) {
-      expr.type = csGen.goal!.substitute(soln)
+      expr.type = csGen.goal.substitute(soln)
     }
     ensureTypesAndLabelsMatch(expr, decl: decl)
   }

--- a/Sources/Semantic Analysis/TypeChecker.swift
+++ b/Sources/Semantic Analysis/TypeChecker.swift
@@ -70,7 +70,7 @@ class TypeChecker: ASTTransformer, Pass {
     return self.withDefinitions([i:t], f)
   }
 
-  func withDefinitions(_ ds: [Identifier:DataType], _ f: () -> Void) {
+  func withDefinitions(_ ds: [Identifier: DataType], _ f: () -> Void) {
     let oldTarget = self.env
     env.unionInPlace(ds)
     f()
@@ -199,15 +199,17 @@ class TypeChecker: ASTTransformer, Pass {
   override func visitVarExpr(_ expr: VarExpr) -> Result {
     self.csGen.reset(with: self.env)
     self.csGen.visit(expr)
-    let soln = Solver.solveSystem(csGen.constraints)
-    expr.type = csGen.goal!.substitute(soln)
+    if let soln = Solver(context: context).solveSystem(csGen.constraints) {
+      expr.type = csGen.goal!.substitute(soln)
+    }
   }
   
   override func visitVarAssignDecl(_ decl: VarAssignDecl) -> Result {
     self.csGen.reset(with: self.env)
     self.csGen.visit(decl)
-    let soln = Solver.solveSystem(csGen.constraints)
-    decl.type = csGen.goal!.substitute(soln)
+    if let soln = Solver(context: context).solveSystem(csGen.constraints) {
+      decl.type = csGen.goal!.substitute(soln)
+    }
     self.env[decl.name] = decl.type
   }
   
@@ -298,8 +300,9 @@ class TypeChecker: ASTTransformer, Pass {
     guard let decl = expr.decl else { return }
     self.csGen.reset(with: self.env)
     self.csGen.visit(expr)
-    let soln = Solver.solveSystem(csGen.constraints)
-    expr.type = csGen.goal!.substitute(soln)
+    if let soln = Solver(context: context).solveSystem(csGen.constraints) {
+      expr.type = csGen.goal!.substitute(soln)
+    }
     ensureTypesAndLabelsMatch(expr, decl: decl)
   }
   

--- a/stdlib/Mirror.tr
+++ b/stdlib/Mirror.tr
@@ -72,7 +72,7 @@ type Mirror {
     }
   }
 
-  func print(to file: *FILE) {
+  func printToFile(_ file: *FILE) {
     if trill_anyIsNil(self.value) != 0 {
       fprintf(file, "nil")
       return
@@ -95,9 +95,9 @@ type Mirror {
       }
       let child = self.child(i)
       var shouldQuote = child is *Int8 || child is String
-//      if shouldQuote { print("\"") }
-//      print(child)
-//      if shouldQuote { print("\"") }
+      if shouldQuote { print("\"") }
+      print(child)
+      if shouldQuote { print("\"") }
     }
     fprintf(file, ")", self.value)
   }

--- a/stdlib/Mirror.tr
+++ b/stdlib/Mirror.tr
@@ -95,9 +95,9 @@ type Mirror {
       }
       let child = self.child(i)
       var shouldQuote = child is *Int8 || child is String
-      if shouldQuote { print("\"") }
-      print(child)
-      if shouldQuote { print("\"") }
+//      if shouldQuote { print("\"") }
+//      print(child)
+//      if shouldQuote { print("\"") }
     }
     fprintf(file, ")", self.value)
   }

--- a/stdlib/print.tr
+++ b/stdlib/print.tr
@@ -28,7 +28,7 @@ func print(_ value: Any) {
   } else if value is AnyArray {
     print(value as AnyArray)
   } else {
-    Mirror(reflecting: value).print(to: stdout)
+    Mirror(reflecting: value).printToFile(stdout)
   }
 }
 

--- a/trill.xcodeproj/project.pbxproj
+++ b/trill.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		82D6E13A1E78E6CA00C791DE /* Solver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D6E1391E78E6CA00C791DE /* Solver.swift */; };
 		C019190A1E6E2B6800FDFB87 /* AnyArray.tr in CopyFiles */ = {isa = PBXBuildFile; fileRef = C01918FA1E6E2AD700FDFB87 /* AnyArray.tr */; };
 		C019190B1E6E2B6800FDFB87 /* AnyDictionary.tr in CopyFiles */ = {isa = PBXBuildFile; fileRef = C01918FB1E6E2AD700FDFB87 /* AnyDictionary.tr */; };
 		C019190C1E6E2B6800FDFB87 /* bytearray.tr in CopyFiles */ = {isa = PBXBuildFile; fileRef = C01918FC1E6E2AD700FDFB87 /* bytearray.tr */; };
@@ -416,6 +417,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		82D6E1391E78E6CA00C791DE /* Solver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Solver.swift; sourceTree = "<group>"; };
 		C01918FA1E6E2AD700FDFB87 /* AnyArray.tr */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = AnyArray.tr; sourceTree = "<group>"; };
 		C01918FB1E6E2AD700FDFB87 /* AnyDictionary.tr */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = AnyDictionary.tr; sourceTree = "<group>"; };
 		C01918FC1E6E2AD700FDFB87 /* bytearray.tr */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = bytearray.tr; sourceTree = "<group>"; };
@@ -1152,6 +1154,7 @@
 				DC8EBB371E5FCFD500AE577C /* Sema.swift */,
 				DC8EBB381E5FCFD500AE577C /* SemaError.swift */,
 				DC8EBB391E5FCFD500AE577C /* TypeChecker.swift */,
+				82D6E1391E78E6CA00C791DE /* Solver.swift */,
 			);
 			name = "Semantic Analysis";
 			path = "Sources/Semantic Analysis";
@@ -1692,6 +1695,7 @@
 				DC8EBB3A1E5FCFD500AE577C /* Mangler.swift in Sources */,
 				DC8EBB401E5FCFD500AE577C /* TypeChecker.swift in Sources */,
 				DC8EBAFE1E5FCFB200AE577C /* RuntimeIRGen.swift in Sources */,
+				82D6E13A1E78E6CA00C791DE /* Solver.swift in Sources */,
 				DC8EBB971E5FD06C00AE577C /* BasicBlock.swift in Sources */,
 				DC8EBBB61E5FD06C00AE577C /* Use.swift in Sources */,
 				DC8EBBA61E5FD06C00AE577C /* JIT.swift in Sources */,

--- a/trill.xcodeproj/project.xcworkspace/xcshareddata/trill.xcscmblueprint
+++ b/trill.xcodeproj/project.xcworkspace/xcshareddata/trill.xcscmblueprint
@@ -8,15 +8,15 @@
     "32E9A4F24A891D682A50DDAB6DE720492519A2F6" : 9223372036854775807,
     "AEC09DBC080A0591BD9DA174AD0FBD8FCCD37CA6" : 9223372036854775807
   },
-  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "EE0E44EB-A09D-42BA-B49A-CFA68EF1EAD1",
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "D0961F10-71A0-419F-8C42-3396BE5A12C1",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
-    "C1B3CEC66847B924F737CEF45B60B75CF8F94BAD" : "Trill\/TinyGC\/",
-    "32E9A4F24A891D682A50DDAB6DE720492519A2F6" : "Trill\/LLVMSwift\/",
-    "AEC09DBC080A0591BD9DA174AD0FBD8FCCD37CA6" : "Trill\/"
+    "C1B3CEC66847B924F737CEF45B60B75CF8F94BAD" : "trill\/TinyGC\/",
+    "32E9A4F24A891D682A50DDAB6DE720492519A2F6" : "trill\/LLVMSwift\/",
+    "AEC09DBC080A0591BD9DA174AD0FBD8FCCD37CA6" : "trill\/"
   },
-  "DVTSourceControlWorkspaceBlueprintNameKey" : "Trill",
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "trill",
   "DVTSourceControlWorkspaceBlueprintVersion" : 204,
-  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "Trill.xcodeproj",
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "trill.xcodeproj",
   "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
     {
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/trill-lang\/LLVMSwift.git",
@@ -24,7 +24,7 @@
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "32E9A4F24A891D682A50DDAB6DE720492519A2F6"
     },
     {
-      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/CodaFi\/trill.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:CodaFi\/trill.git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "AEC09DBC080A0591BD9DA174AD0FBD8FCCD37CA6"
     },

--- a/trill.xcodeproj/project.xcworkspace/xcshareddata/trill.xcscmblueprint
+++ b/trill.xcodeproj/project.xcworkspace/xcshareddata/trill.xcscmblueprint
@@ -8,15 +8,15 @@
     "32E9A4F24A891D682A50DDAB6DE720492519A2F6" : 9223372036854775807,
     "AEC09DBC080A0591BD9DA174AD0FBD8FCCD37CA6" : 9223372036854775807
   },
-  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "D0961F10-71A0-419F-8C42-3396BE5A12C1",
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "EE0E44EB-A09D-42BA-B49A-CFA68EF1EAD1",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
-    "C1B3CEC66847B924F737CEF45B60B75CF8F94BAD" : "trill\/TinyGC\/",
-    "32E9A4F24A891D682A50DDAB6DE720492519A2F6" : "trill\/LLVMSwift\/",
-    "AEC09DBC080A0591BD9DA174AD0FBD8FCCD37CA6" : "trill\/"
+    "C1B3CEC66847B924F737CEF45B60B75CF8F94BAD" : "Trill\/TinyGC\/",
+    "32E9A4F24A891D682A50DDAB6DE720492519A2F6" : "Trill\/LLVMSwift\/",
+    "AEC09DBC080A0591BD9DA174AD0FBD8FCCD37CA6" : "Trill\/"
   },
-  "DVTSourceControlWorkspaceBlueprintNameKey" : "trill",
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "Trill",
   "DVTSourceControlWorkspaceBlueprintVersion" : 204,
-  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "trill.xcodeproj",
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "Trill.xcodeproj",
   "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
     {
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/trill-lang\/LLVMSwift.git",
@@ -24,7 +24,7 @@
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "32E9A4F24A891D682A50DDAB6DE720492519A2F6"
     },
     {
-      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:trill-lang\/trill.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/CodaFi\/trill.git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "AEC09DBC080A0591BD9DA174AD0FBD8FCCD37CA6"
     },

--- a/trill.xcodeproj/xcshareddata/xcschemes/Trill.xcscheme
+++ b/trill.xcodeproj/xcshareddata/xcschemes/Trill.xcscheme
@@ -68,23 +68,23 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "$(PROJECT_DIR)/stdlib/Int.tr"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "$(PROJECT_DIR)/stdlib/Mirror.tr"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "$(PROJECT_DIR)/stdlib/String.tr"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "$(PROJECT_DIR)/stdlib/bytearray.tr"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "$(PROJECT_DIR)/stdlib/print.tr"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
       <AdditionalOptions>


### PR DESCRIPTION
Adds two new forms of shorthand for closures.  This necessitated modeling type variables and starting the most rudimentary of solvers in the TypeChecker.

<strike>YOUR PARSER MAKES TYPE VARIABLES, I HOPE YOU'RE HAPPY</strike>