### PR TITLE
Improve parse errors

### DIFF
--- a/Sources/IRGen/FunctionIRGen.swift
+++ b/Sources/IRGen/FunctionIRGen.swift
@@ -308,7 +308,7 @@ extension IRGenerator {
 
 extension Array {
   subscript(safe index: Int) -> Element? {
-    guard index < count else { return nil }
+    guard index < count, index >= 0 else { return nil }
     return self[index]
   }
 }

--- a/Sources/Infrastructure/StreamConsumer.swift
+++ b/Sources/Infrastructure/StreamConsumer.swift
@@ -69,12 +69,21 @@ class StreamConsumer<StreamType: ColoredStream>: DiagnosticConsumer {
             let lineStr = "\(loc.line)"
             let indentation = "\(indent(lineStr.characters.count))"
             stream.write(" \(indentation)|\n", with: [.cyan])
+            if let prior = file?.lines[loc.line - 2] {
+              stream.write(" \(indentation)|", with: [.cyan])
+              stream.write("\(prior)\n")
+            }
             stream.write(" \(lineStr)| ", with: [.cyan])
             stream.write("\(line)\n")
             stream.write(" \(indentation)| ", with: [.cyan])
             stream.write(highlightString(forDiag: diagnostic),
                          with: [.bold, .green])
-            stream.write("\n\n")
+            stream.write("\n")
+            if let next = file?.lines[loc.line] {
+              stream.write(" \(indentation)|", with: [.cyan])
+              stream.write("\(next)\n")
+            }
+            stream.write("\n")
         }
     }
 }

--- a/Sources/Infrastructure/StreamConsumer.swift
+++ b/Sources/Infrastructure/StreamConsumer.swift
@@ -69,8 +69,8 @@ class StreamConsumer<StreamType: ColoredStream>: DiagnosticConsumer {
             let lineStr = "\(loc.line)"
             let indentation = "\(indent(lineStr.characters.count))"
             stream.write(" \(indentation)|\n", with: [.cyan])
-            if let prior = file?.lines[loc.line - 2] {
-              stream.write(" \(indentation)|", with: [.cyan])
+            if let prior = file?.lines[safe: loc.line - 2] {
+              stream.write(" \(indentation)| ", with: [.cyan])
               stream.write("\(prior)\n")
             }
             stream.write(" \(lineStr)| ", with: [.cyan])
@@ -79,8 +79,8 @@ class StreamConsumer<StreamType: ColoredStream>: DiagnosticConsumer {
             stream.write(highlightString(forDiag: diagnostic),
                          with: [.bold, .green])
             stream.write("\n")
-            if let next = file?.lines[loc.line] {
-              stream.write(" \(indentation)|", with: [.cyan])
+            if let next = file?.lines[safe: loc.line] {
+              stream.write(" \(indentation)| ", with: [.cyan])
               stream.write("\(next)\n")
             }
             stream.write("\n")

--- a/Sources/Parse/BaseParser.swift
+++ b/Sources/Parse/BaseParser.swift
@@ -77,9 +77,8 @@ class Parser {
   }
   
   func unexpectedToken() -> Error {
-    let end = adjustedEnd()
     return Diagnostic.error(ParseError.unexpectedToken(token: peek()),
-                            loc: end,
+                            loc: currentToken().range.start,
                             highlights: [
                               currentToken().range
                         ])


### PR DESCRIPTION
Given the following source:

```trill
func main() {
  let f: () -> Void = {
    return
  }
  println(f)
}
```

Turn the error from

```
error: unexpected token 'return'
 --> test.tr:2:24
  |
 2|   let f: () -> Void = {
  |                        ^
```

into

```
error: unexpected token 'return'
 --> test.tr:3:5
  |
  |  let f: () -> Void = {
 3|     return
  |     ^~~~~~ 
  |  }
```