### PR TITLE
Fixed mutating strings and byte arrays

### DIFF
--- a/examples/dict-test.tr
+++ b/examples/dict-test.tr
@@ -1,7 +1,7 @@
 func main(argc: Int, argv: **Int8) {
   var dict = AnyDictionary()
   for var i = 0; i < argc; i += 1 {
-    dict.insert(i, forKey: argv[i] + "foo")
+    dict.insert(i, forKey: String(cString: argv[i]) + "foo")
   }
   dict.dump()
 }

--- a/examples/multi-file/file1.tr
+++ b/examples/multi-file/file1.tr
@@ -3,7 +3,9 @@ extension Int {
         let length = floor(log10(labs(self) as Double)) as Int + 2
         let str = calloc(length, sizeof(Int8)) as *Int8
         snprintf(str, (length * sizeof(Int8)) as UInt, "%d", self)
-        return String(_owning: str, length: length)
+        let string = String(cString: str)
+        free(str as *Void)
+        return string
     }
 }
 
@@ -21,6 +23,5 @@ func main() {
     print("oneThousand.hash: ")
     println(oneThousand.hash)
     println(oneThousand.isEmpty)
-    let sorted = oneThousand.mergeSorted()
     print(oneThousand)
 }

--- a/examples/string.tr
+++ b/examples/string.tr
@@ -56,7 +56,9 @@ func read(file: *Int8) -> String {
   fread(str as *Void, fsize, 1, f)
   fclose(f)
   str[fsize] = 0 as Int8
-  return String(_owning: str, length: fsize)
+  let string = String(cString: str)
+  free(str as *Void)
+  return string
 }
 
 func main(argc: Int, argv: **Int8) {

--- a/stdlib/String.tr
+++ b/stdlib/String.tr
@@ -79,6 +79,14 @@ type String {
     func copy() -> String {
         return String(_storage: self._storage.copy())
     }
+    func reversed() -> String {
+        var storage = ByteArray(capacity: self.length + 1)
+        for var i = self.length - 1; i >= 0; i -= 1 {
+            storage.append(self[i])
+        }
+        storage.append(0)
+        return String(_storage: storage)
+    }
     subscript(_ index: Int) -> Int8 {
         return self._storage[index]
     }

--- a/stdlib/String.tr
+++ b/stdlib/String.tr
@@ -13,6 +13,17 @@ type String {
         self._storage = ByteArray(cString, length: length)
         self._storage.append(0)
     }
+    /// Creates a string by repeating a character for a certain length.
+    /// - parameter count: The number of times to repeat the character.
+    init(repeating string: String, count: Int) {
+        self._storage = ByteArray(capacity: (string.length * count) + 1)
+        for var i = 0; i < count; i += 1 {
+            self._storage.insert(string.cString, 
+                                 length: string.length,
+                                 at: self._storage.length)
+        }
+        self._storage.append(0)
+    }
     init() {
         self._storage = ByteArray(capacity: 256)
         self._storage.append(0)

--- a/stdlib/String.tr
+++ b/stdlib/String.tr
@@ -1,76 +1,66 @@
 type String {
+    // Underlying storage for String.
+    // - note: MUST always end in a NUL terminator.
     var _storage: ByteArray
     init(cString: *Int8) {
         self._storage = ByteArray(cString)
         self._storage.append(0)
-    }
-    init(_owning cString: *Int8, length: Int) {
-        self._storage = ByteArray(_owning: cString, length: length)
     }
     init(_global cString: *Int8, length: Int) {
         // TODO: make this not call into a ByteArray initializer
         // that immediately allocates a new buffer -- it should be
         // CoW
         self._storage = ByteArray(cString, length: length)
+        self._storage.append(0)
     }
     init() {
         self._storage = ByteArray(capacity: 256)
         self._storage.append(0)
     }
     var length: Int {
-        return self._storage.length
+        return self._storage.length - 1
     }
     var cString: *Int8 {
         return self._storage.bytes
     }
     mutating func append(_ char: Int8) {
-        self._storage.remove(at: self._storage.length)
+        self._storage.remove(at: self.length) // Remove NUL terminator
         self._storage.append(char)
         self._storage.append(0)
     }
     mutating func append(_ string: String) {
-        self._storage.remove(at: self._storage.length)
+        self._storage.remove(at: self.length) // Remove NUL terminator
         self._storage.append(string._storage)
         self._storage.append(0)
     }
     mutating func append(_ cString: *Int8) {
-        self._storage.remove(at: self._storage.length)
+        self._storage.remove(at: self.length) // Remove NUL terminator
         self._storage.append(cString)
         self._storage.append(0)
     }
     mutating func append(_ cString: *Int8, length: Int) {
-        self._storage.remove(at: self.length)
+        self._storage.remove(at: self.length) // Remove NUL terminator
         self._storage.insert(cString, length: length, at: self.length)
         self._storage.append(0)
     }
     mutating func insert(_ cString: *Int8, length: Int, at index: Int) {
-        if index == self.length {
-            self._storage.remove(at: self.length)
+        let isEnd = index == self.length
+        if isEnd {
+            self._storage.remove(at: self.length) // Remove NUL terminator
         }
         self._storage.insert(cString, length: length, at: index)
-        if index == self.length {
+        if isEnd {
             self._storage.append(0)
         }
+    }
+    mutating func insert(_ char: Int8, at index: Int) {
+        self.insert(&char, length: 1, at: index)
     }
     mutating func insert(_ cString: *Int8, at index: Int) {
-        let isEnd = index == self.length
-        if isEnd {
-            self._storage.remove(at: self.length)
-        }
-        self._storage.insert(cString, at: index)
-        if isEnd {
-            self._storage.append(0)
-        }
+        self.insert(cString, length: strlen(cString) as Int, at: index)
     }
     mutating func insert(_ string: String, at index: Int) {
-        let isEnd = index == self.length
-        if isEnd {
-            self._storage.remove(at: self.length)
-        }
-        self._storage.insert(string._storage, at: index)
-        if isEnd {
-            self._storage.append(0)
-        }
+        self.insert(string.cString, length: string.length, at: index)
     }
     func copy() -> String {
         return String(_storage: self._storage.copy())

--- a/stdlib/String.tr
+++ b/stdlib/String.tr
@@ -62,6 +62,9 @@ type String {
     mutating func insert(_ string: String, at index: Int) {
         self.insert(string.cString, length: string.length, at: index)
     }
+    mutating func remove(at index: Int) {
+        self._storage.remove(at: index)
+    }
     func copy() -> String {
         return String(_storage: self._storage.copy())
     }
@@ -90,8 +93,14 @@ type String {
         }
         return true
     }
-    func mergeSorted() -> String {
-        return String(_storage: self._storage.mergeSorted())
+    func substring(from start: Int, to end: Int) -> String {
+      return String(_storage: self._storage.slice(from: start, to: end))
+    }
+    func substring(to end: Int) -> String {
+      return self.substring(from: 0, to: end)
+    }
+    func substring(from start: Int) -> String {
+      return self.substring(from: start, to: self.length + 1 /* index of NUL terminator */)
     }
     var isEmpty: Bool {
         return self.length == 0
@@ -111,12 +120,6 @@ func +(lhs: String, rhs: String) -> String {
   var copy = lhs.copy()
   copy.append(rhs)
   return copy
-}
-
-func +(lhs: *Int8, rhs: *Int8) -> String {
-  var str = String(cString: lhs)
-  str.append(rhs)
-  return str
 }
 
 func fatalError(_ message: String) {

--- a/stdlib/bytearray.tr
+++ b/stdlib/bytearray.tr
@@ -14,24 +14,22 @@ indirect type ByteArray {
     self.bytes = calloc(capacity, sizeof(Int8)) as *Int8
     self.length = 0
   }
+
   init(_ string: *Int8) {
-    let length = strlen(string)
-    self.capacity = (length as Double * 1.5) as Int
+    var length = strlen(string)
+    self.capacity = ((length + 1) as Double * 1.5) as Int
     self.bytes = calloc(self.capacity, sizeof(Int8)) as *Int8
     self.length = length as Int
     strncpy(self.bytes, string, length as UInt)
   }
-  init(_owning bytes: *Int8, length: Int) {
-    self.capacity = length
-    self.length = length
-    self.bytes = bytes
-  }
+
   init(_ string: *Int8, length: Int) {
-    self.capacity = (length as Double * 1.5) as Int
+    self.capacity = ((length + 1) as Double * 1.5) as Int
     self.bytes = calloc(self.capacity, sizeof(Int8)) as *Int8
     self.length = length
     strncpy(self.bytes, string, length as UInt)
   }
+
   mutating func _growIfNeeded() {
     if self._load > 0.75 {
       self.capacity *= 2
@@ -47,7 +45,7 @@ indirect type ByteArray {
   mutating func _reserveCapacity(_ capacity: Int) {
     if self.capacity >= capacity { return }
     self.capacity = capacity
-    self.bytes = realloc(self.bytes as *Void, self.capacity) as *Int8
+    self.bytes = realloc(self.bytes as *Void, self.capacity * sizeof(Int8)) as *Int8
   }
   func _boundsCheck(_ index: Int) {
     if index > self.length {
@@ -55,9 +53,10 @@ indirect type ByteArray {
     }
   }
   mutating func append(_ element: Int8) {
-    self.bytes[self.length] = element
+    let index = self.length
     self.length += 1
     self._growIfNeeded()
+    self.bytes[index] = element
   }
   mutating func append(_ string: *Int8) {
     self.insert(string, at: self.length)
@@ -74,9 +73,17 @@ indirect type ByteArray {
     self._boundsCheck(index)
     self.length += length
     self._growIfNeeded()
+
+    // "foo" -> insert "bar" at 0
+    // "   foo" -> move foo to new location (0 + 3 = 3)
+    // "barfoo" -> copy bar into space
+
+    // "foo" -> insert "bar" at 1
+    // "f   oo" -> move "oo" to new location (1 + 3 = 4)
+    // "fbaroo" -> copy bar into space
     memmove(&self.bytes[index + length] as *Void,
             &self.bytes[index] as *Void,
-            length as UInt)
+            (self.length - index) as UInt)
     strncpy(&self.bytes[index], string, length as UInt)
   }
   mutating func insert(_ element: Int8, at index: Int) {
@@ -85,13 +92,15 @@ indirect type ByteArray {
   mutating func insert(_ array: ByteArray, at index: Int) {
     self.insert(array.bytes, length: array.length, at: index)
   }
-  mutating func remove(at index: Int) -> Int8 {
+  mutating func remove(at index: Int) {
     self._boundsCheck(index)
     self._shrinkIfNeeded()
     self.length -= 1
+
     memmove(&self.bytes[index] as *Void,
-            &self.bytes[index + 1] as *Void, 1)
-    return self.bytes[self.length + 1]
+            &self.bytes[index + 1] as *Void,
+            (self.length - index) as UInt)
+    self.bytes[self.length] = 0
   }
   subscript(_ index: Int) -> Int8 {
     self._boundsCheck(index)
@@ -110,13 +119,13 @@ indirect type ByteArray {
   func dump() {
     printf("capacity: %d, length: %d (load %f)\n", self.capacity, self.length, self._load)
     putchar('[' as Int32)
-      for var i = 0; i < self.length; i += 1 {
-        printf("0x%x", self.bytes[i] as Int)
-        if i != self.length - 1 {
-          print(", ")
-        }
+    for var i = 0; i < self.length; i += 1 {
+      printf("0x%x", self.bytes[i] as Int)
+      if i != self.length - 1 {
+        printf(", ")
       }
-      println("]")
+    }
+    puts("]" as *Int8)
   }
   func slice(from start: Int, to end: Int) -> ByteArray {
     assert(end >= start, "invalid slice bounds")

--- a/stdlib/bytearray.tr
+++ b/stdlib/bytearray.tr
@@ -68,7 +68,7 @@ indirect type ByteArray {
     self.insert(string, length: strlen(string) as Int, at: index)
   }
   mutating func insert(_ string: *Int8, length: Int, at index: Int) {
-    var length = length
+    let length = length
     var index = index
     self._boundsCheck(index)
     self.length += length

--- a/stdlib/print.tr
+++ b/stdlib/print.tr
@@ -46,7 +46,7 @@ func print(_ string: *Int8) {
 }
 
 func print(_ bool: Bool) {
-    printf("%s", bool ? "true" : "false")
+    print(bool ? "true" as *Int8 : "false" as *Int8)
 }
 
 func print(_ int: Int) {


### PR DESCRIPTION
We weren't properly tracking and ensuring the NUL terminator, and our `memmove` calls were not moving the entire string out of the way, only the length that's passed in. Oops.