### PR TITLE
Convert the `as` and `is` operators into their own Expr subclasses.

### DIFF
--- a/Sources/Base/ASTContext.swift
+++ b/Sources/Base/ASTContext.swift
@@ -762,7 +762,10 @@ public class ASTContext {
     }
   }
   
-  func canCoerce(_ type: DataType, to other: DataType) -> Bool {
+  func canCoerce(_ _type: DataType, to _other: DataType) -> Bool {
+    let type = canonicalType(_type)
+    let other = canonicalType(_other)
+    
     // You should be able to cast between an indirect type and a pointer.
     if isIndirect(other), case .pointer = type {
       return true

--- a/Sources/Base/ASTContext.swift
+++ b/Sources/Base/ASTContext.swift
@@ -762,9 +762,9 @@ public class ASTContext {
     }
   }
   
-  func canCoerce(_ _type: DataType, to _other: DataType) -> Bool {
-    let type = canonicalType(_type)
-    let other = canonicalType(_other)
+  func canCoerce(_ type: DataType, to other: DataType) -> Bool {
+    let type = canonicalType(type)
+    let other = canonicalType(other)
     
     // You should be able to cast between an indirect type and a pointer.
     if isIndirect(other), case .pointer = type {

--- a/Sources/Base/ASTTransformer.swift
+++ b/Sources/Base/ASTTransformer.swift
@@ -278,6 +278,16 @@ class ASTTransformer: ASTVisitor {
   func visitExprStmt(_ stmt: ExprStmt) -> () {
     visit(stmt.expr)
   }
+
+  func visitIsExpr(_ expr: IsExpr) -> Void {
+    visit(expr.lhs)
+    visit(expr.rhs)
+  }
+
+  func visitCoercionExpr(_ expr: CoercionExpr) -> Void {
+    visit(expr.lhs)
+    visit(expr.rhs)
+  }
   
   func visitInfixOperatorExpr(_ expr: InfixOperatorExpr) {
     visit(expr.lhs)

--- a/Sources/Base/ASTVisitor.swift
+++ b/Sources/Base/ASTVisitor.swift
@@ -97,6 +97,10 @@ protocol ASTVisitor {
   @discardableResult
   func visitSwitchStmt(_ expr: SwitchStmt) -> Result
   @discardableResult
+  func visitIsExpr(_ expr: IsExpr) -> Result
+  @discardableResult
+  func visitCoercionExpr(_ expr: CoercionExpr) -> Result
+  @discardableResult
   func visitInfixOperatorExpr(_ expr: InfixOperatorExpr) -> Result
   @discardableResult
   func visitPrefixOperatorExpr(_ expr: PrefixOperatorExpr) -> Result
@@ -215,6 +219,10 @@ extension ASTVisitor {
       return visitTypeRefExpr(expr)
     case let expr as NilExpr:
       return visitNilExpr(expr)
+    case let expr as CoercionExpr:
+      return visitCoercionExpr(expr)
+    case let expr as IsExpr:
+      return visitIsExpr(expr)
     case let expr as InfixOperatorExpr:
       return visitInfixOperatorExpr(expr)
     case let expr as PrefixOperatorExpr:

--- a/Sources/Base/Operators.swift
+++ b/Sources/Base/Operators.swift
@@ -41,8 +41,6 @@ enum BuiltinOperator: String, CustomStringConvertible {
   case xorAssign = "^="
   case rightShiftAssign = ">>="
   case leftShiftAssign = "<<="
-  case `as` = "as"
-  case `is` = "is"
   
   var isPrefix: Bool {
     return self == .bitwiseNot || self == .not ||
@@ -81,9 +79,6 @@ enum BuiltinOperator: String, CustomStringConvertible {
   var infixPrecedence: Int {
     switch self {
 
-    case .as: return 170
-    case .is: return 170
-      
     case .leftShift: return 160
     case .rightShift: return 160
       
@@ -147,7 +142,6 @@ class PrefixOperatorExpr: Expr {
     case (.not, .bool): return .bool
     case (.ampersand, let type): return .pointer(type: type)
     case (.bitwiseNot, .int): return argType
-    case (.is, _): return .bool
     default: return nil
     }
   }

--- a/Sources/Base/Values.swift
+++ b/Sources/Base/Values.swift
@@ -280,3 +280,35 @@ class TernaryExpr: Expr {
     super.init(sourceRange: sourceRange)
   }
 }
+
+/// <expr> as <expr>
+class CoercionExpr: Expr {
+  let lhs: Expr
+  let rhs: TypeRefExpr
+  let asRange: SourceRange?
+
+  init(lhs: Expr, rhs: TypeRefExpr,
+       asRange: SourceRange? = nil,
+       sourceRange: SourceRange? = nil) {
+    self.lhs = lhs
+    self.asRange = asRange
+    self.rhs = rhs
+    super.init(sourceRange: sourceRange)
+  }
+}
+
+/// <expr> is <expr>
+class IsExpr: Expr {
+  let lhs: Expr
+  let rhs: TypeRefExpr
+  let isRange: SourceRange?
+
+  init(lhs: Expr, rhs: TypeRefExpr,
+       isRange: SourceRange? = nil,
+       sourceRange: SourceRange? = nil) {
+    self.lhs = lhs
+    self.isRange = isRange
+    self.rhs = rhs
+    super.init(sourceRange: sourceRange)
+  }
+}

--- a/Sources/IRGen/TypeIRGen.swift
+++ b/Sources/IRGen/TypeIRGen.swift
@@ -92,8 +92,8 @@ extension IRGenerator {
   /// ```
   ///
   /// There is a unique metadata record for every type at compile time.
-  func codegenTypeMetadata(_ _type: DataType) -> Global {
-    let type = context.canonicalType(_type)
+  func codegenTypeMetadata(_ type: DataType) -> Global {
+    let type = context.canonicalType(type)
     if let cached = typeMetadataMap[type] { return cached }
     var pointerLevel = 0
     let fullName = type.description

--- a/Sources/IRGen/TypeIRGen.swift
+++ b/Sources/IRGen/TypeIRGen.swift
@@ -261,7 +261,7 @@ extension IRGenerator {
     case let expr as TupleFieldLookupExpr:
       let lhs = resolvePtr(expr.lhs)
       return builder.buildStructGEP(lhs, index: expr.field, name: "tuple-ptr")
-    case let expr as InfixOperatorExpr where expr.op == .as:
+    case let expr as CoercionExpr:
       if let type = expr.type, case .any = context.canonicalType(type) {
         return codegenAnyValuePtr(visit(expr)!, type: expr.rhs.type!)
       }

--- a/Sources/IRGen/ValueIRGen.swift
+++ b/Sources/IRGen/ValueIRGen.swift
@@ -294,22 +294,20 @@ extension IRGenerator {
   func visitParenExpr(_ expr: ParenExpr) -> Result {
     return visit(expr.value)
   }
+
+  func visitIsExpr(_ expr: IsExpr) -> Result {
+    let lhs = visit(expr.lhs)!
+    return codegenTypeCheck(lhs, type: expr.rhs.type!)
+  }
+
+  func visitCoercionExpr(_ expr: CoercionExpr) -> Result {
+    let lhs = visit(expr.lhs)!
+    return coerce(lhs, from: expr.lhs.type!, to: expr.type!)
+  }
   
   func visitInfixOperatorExpr(_ expr: InfixOperatorExpr) -> Result {
     if [.and, .or].contains(expr.op) {
       return codegenShortCircuit(expr)
-    }
-    
-    if case .as = expr.op {
-      let lhs: IRValue
-
-      lhs = visit(expr.lhs)!
-      return coerce(lhs, from: expr.lhs.type!, to: expr.type!)
-    }
-    
-    if case .is = expr.op {
-      let lhs = visit(expr.lhs)!
-      return codegenTypeCheck(lhs, type: expr.rhs.type!)
     }
     
     var rhs = visit(expr.rhs)!

--- a/Sources/Parse/Lexer.swift
+++ b/Sources/Parse/Lexer.swift
@@ -41,6 +41,8 @@ enum TokenKind: Equatable {
   case `nil`
   case `if`
   case `in`
+  case `as`
+  case `is`
   case `else`
   case `var`
   case `let`
@@ -111,8 +113,8 @@ enum TokenKind: Equatable {
     case "default": self = .default
     case "for": self = .for
     case "nil": self = .nil
-    case "as": self = .operator(.as)
-    case "is": self = .operator(.is)
+    case "as": self = .as
+    case "is": self = .is
     case "#function": self = .poundFunction
     case "#file": self = .poundFile
     case "#line": self = .poundLine
@@ -153,6 +155,8 @@ enum TokenKind: Equatable {
     case .nil: return "nil"
     case .if: return "if"
     case .in: return "in"
+    case .as: return "as"
+    case .is: return "is"
     case .else: return "else"
     case .var: return "var"
     case .let: return "let"
@@ -183,15 +187,14 @@ enum TokenKind: Equatable {
   
   var isKeyword: Bool {
     switch self {
-    case .func, .while, .if, .in, .else, .for, .nil, .break, .case, .switch,
-         .default, .continue, .return, .underscore, .extension, .sizeOf, .where,
+    case .func, .while, .if, .in, .as, .is, .else, .for, .nil, .break, .case,
+         .switch, .default, .continue, .return, .underscore, .extension, .where,
          .protocol, .subscript, .var, .let, .type, .true, .false, .Init, .deinit,
-         .poundFunction, .poundFile, .poundLine, .poundWarning, .poundError:
+         .sizeOf, .poundFunction, .poundFile, .poundLine, .poundWarning,
+         .poundError:
          return true
     case .identifier(let value):
         return DeclModifier(rawValue: value) != nil || value == "self"
-    case .operator(op: .as): return true
-    case .operator(op: .is): return true
     default: return false
     }
   }
@@ -266,6 +269,8 @@ func ==(lhs: TokenKind, rhs: TokenKind) -> Bool {
   case (.nil, .nil): return true
   case (.if, .if): return true
   case (.in, .in): return true
+  case (.as, .as): return true
+  case (.is, .is): return true
   case (.else, .else): return true
   case (.var, .var): return true
   case (.let, .let): return true

--- a/Sources/Semantic Analysis/TypeChecker.swift
+++ b/Sources/Semantic Analysis/TypeChecker.swift
@@ -286,9 +286,7 @@ class TypeChecker: ASTTransformer, Pass {
   override func visitInfixOperatorExpr(_ expr: InfixOperatorExpr) -> Result {
     guard let lhsType = expr.lhs.type else { return }
     guard let rhsType = expr.rhs.type else { return }
-    if [.as, .is].contains(expr.op) {
-      // thrown from sema
-    } else if expr.op.isAssign {
+    if expr.op.isAssign {
       // thrown from sema
       if case .assign = expr.op {
         if case .any = context.canonicalType(rhsType),

--- a/Sources/Utility Passes/ASTDumper.swift
+++ b/Sources/Utility Passes/ASTDumper.swift
@@ -310,4 +310,14 @@ class ASTDumper<StreamType: ColoredStream>: ASTTransformer {
       super.visitPoundDiagnosticStmt(stmt)
     }
   }
+  override func visitIsExpr(_ expr: IsExpr) -> Void {
+    printNode(expr) {
+      super.visitIsExpr(expr)
+    }
+  }
+  override func visitCoercionExpr(_ expr: CoercionExpr) -> Void {
+    printNode(expr) {
+      super.visitCoercionExpr(expr)
+    }
+  }
 }

--- a/Sources/Utility Passes/JavaScriptGen.swift
+++ b/Sources/Utility Passes/JavaScriptGen.swift
@@ -135,14 +135,19 @@ class JavaScriptGen<StreamType: TextOutputStream>: ASTTransformer {
     stream.write("return ")
     visit(expr.value)
   }
+
+  override func visitCoercionExpr(_ expr: CoercionExpr) {
+    visit(expr.rhs)
+  }
+
+  override func visitIsExpr(_ expr: IsExpr) {
+    visit(expr.lhs)
+    stream.write(" instanceof ")
+    visit(expr.rhs)
+  }
   
   override func visitInfixOperatorExpr(_ expr: InfixOperatorExpr) {
     let emit: () -> Void = {
-      if case .as = expr.op {
-        self.visit(expr.lhs)
-        return
-      }
-      
       if let decl = expr.decl,
         !decl.has(attribute: .foreign),
         !decl.has(attribute: .implicit) {

--- a/Sources/Utility Passes/JavaScriptGen.swift
+++ b/Sources/Utility Passes/JavaScriptGen.swift
@@ -137,7 +137,7 @@ class JavaScriptGen<StreamType: TextOutputStream>: ASTTransformer {
   }
 
   override func visitCoercionExpr(_ expr: CoercionExpr) {
-    visit(expr.rhs)
+    visit(expr.lhs)
   }
 
   override func visitIsExpr(_ expr: IsExpr) {


### PR DESCRIPTION
There's more duplication than I'd like, but it's pretty simple.